### PR TITLE
Adds Project Board to website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,5 +37,7 @@ collections:
     output: true
   platforms:
     output: true
+  projects:
+    output: true
 
 markdown: kramdown

--- a/_data/project-board.yml
+++ b/_data/project-board.yml
@@ -1,0 +1,29 @@
+- project-status: Backlog
+  limit:
+
+- project-status: Scoping
+  limit:
+
+- project-status: Documenting
+  limit:
+
+- project-status: Governance
+  limit:
+
+- project-status: Contracting
+  limit:
+
+- project-status: Data Curating
+  limit:
+
+- project-status: Developing
+  limit:
+
+- project-status: Evaluating
+  limit:
+
+- project-status: Reporting
+  limit:
+
+- project-status: Graveyard
+  limit:

--- a/_includes/project-card.html
+++ b/_includes/project-card.html
@@ -1,0 +1,16 @@
+<!-- Project Card -->
+<div class="col-sm-4 pb-5" id="blogCard" >
+	<a href="{{ project.url }}">
+		<div class="card">
+			<div class="card__header">
+				<img src="{{ project.image }}" alt="card__image" class="card__image" width="350" height= "300" style="object-fit: cover" >
+			</div>
+			<div class="card__body">
+				<h4>{{ project.title }}</h4>
+				<p>{{ project.summary }}</p>
+			</div>
+		</div>
+	</a>
+</div>
+<!-- Project Card -->
+

--- a/_includes/subnav-ourwork.html
+++ b/_includes/subnav-ourwork.html
@@ -29,7 +29,7 @@
   		<div class="collapse navbar-collapse" id="navbarResponsive">
   			<ul class="navbar-nav ml-auto text-uppercase">
               <li class="nav-item">
-                <a class="nav-link js-scroll-trigger" href="/ourwork.html">Kanban Board</a>
+                <a class="nav-link js-scroll-trigger" href="/ourwork.html">Projects</a>
               </li>
               <li class="nav-item">
                 <a class="nav-link js-scroll-trigger" href="/resources.html">Resources</a>

--- a/_layouts/project_board.html
+++ b/_layouts/project_board.html
@@ -1,0 +1,36 @@
+---
+layout: default
+---
+{% include nav.html %}
+{% include subnav-ourwork.html %}
+
+<!--Intro-->
+<div class="container py-5" id="pagecontainer">
+    <h1>{{ page.title }}</h1>
+    {{ content }}
+</div>
+<!--Intro-->
+
+<!--Project Stages-->
+{% for status in site.data.project-board %}
+<section class="page-section {% cycle 'bg-light', 'white' %}" id="{{ status.project-status }}">
+    <div class="container" id="pagecontainer">
+        <h2 class="section-heading pb-3">{{ status.project-status }}</h2>
+        <div class="row pt-3">
+
+            <!--Project Cards-->
+            {% for project in site.projects %}
+
+            {% if project.status == status.project-status %}
+                {% include project-card.html %}
+            {% endif %}
+
+            {% endfor %}
+            <!--Project Cards-->
+        </div>
+    </div>
+</section>
+{% endfor %}
+<!--Project Stages-->
+
+

--- a/_projects/AIC001-lung_nodule.md
+++ b/_projects/AIC001-lung_nodule.md
@@ -1,0 +1,27 @@
+---
+layout: ourwork
+title: Lung Nodules
+status: Backlog
+image: /assets/img/blog/nhs_logo.png
+summary: Automatic lung nodule detection and characterisation on CT Chest
+csc-lead: <a href="team_member/Anil.html">Anil</a>
+modality: Low-dose CT (LDCT) of the chest
+pathology: Lung nodule growth, lung cancer
+rationale: The identification and characterisation of lung nodules for lung cancer indication is a repetitive and time-consuming process, and the burden of small team specialist thoracic radiologists. AI software that performs as well as a thoracic radiologist could provide initial assessment on all low-dose chest CT’s with incidental lung nodule pick-ups.
+patient-pathway: In virtual clinics, Thoracic Radiologists and Physicians discuss patients with incidental nodules picked up on CT's done for other reasons. Preparation for these meeting is time consuming. 
+training-data: 200 patients – found on PACS retrospectively using the patients from Lung nodule clinics. All patients for lung nodule follow-up are imaged with a standard low dose chest CT protocol.
+errors: Patients do not receive follow up for lung cancer, leading to worse outcomes for patients, more complex treatment, higher costs of treatment. Patients receive needless imaging and investigations. Incorrect volume assessment leads to misdiagnosis of lung nodules. Pipeline failure could result in delayed/missed diagnoses. 
+goals: An automated computer aided diagnostic tool integrated with the low-dose chest CT protocol which accurately detects and characterises Lung nodules and reports the patient for further investigation, resulting in a more streamlined workflow that is efficient at screening for lung cancer.
+success-criteria: Non-inferiority to trained thoracic radiologist for lung nodule detection. Reduction in radiologist workload.
+alternatives: Veye Chest (Aidence) <a href="https://www.nice.org.uk/advice/mib243/resources/artificial-intelligence-for-analysing-chest-ct-images-pdf-2285965631267269"> Report </a>
+---
+
+Despite there being no current national screening program for lung cancer in the UK, some areas in England offer Lung 
+Health Checks targeting the high-risk populations. Screening is achieved through low-dose chest CT but requires a 
+trained thoracic radiologist to accurately detect and characterise lung nodules; a process that is repetitive and time 
+consuming. Lung nodules can be hard to identify, and a volumetric assessment is required for lung cancer indication.
+
+General radiologists assessing a patients’ chest LDCT performed for other reasons may lack the impetus/training to 
+detect lung nodules, potentially missing diagnoses. An AI software that could pre-read and report lung nodules means 
+general radiologists could produce nodule management plans not dissimilar to that reported by a thoracic radiologist, 
+therefore improving confidence in cancer work, and reducing the burden on thoracic radiologists.

--- a/_projects/AIC002-occult-carpal-detection-xray.md
+++ b/_projects/AIC002-occult-carpal-detection-xray.md
@@ -1,0 +1,37 @@
+---
+layout: ourwork
+title: X-Ray Occult Carpal Detection
+status: Data Curating
+image: /assets/img/blog/nhs_logo.png
+summary: This is a project summary.
+csc-lead:
+modality:
+pathology:
+rationale:
+patient-pathway: 
+training-data: 
+errors: 
+goals: 
+success-criteria: 
+alternatives: 
+---
+
+# **Carpal fracture detection in x-ray**
+
+| <b>Project Title</b> | Fracture: Occult Carpal Detection in X-Ray -- Next Steps post TOHETI |
+| <b>Clinical lead(s)</b> |  |
+| <b>CSC lead</b> | [Dika](/team/dika.html) |
+| <b>AI Centre Number</b> | AIC002 |
+| <b>Rationale</b> | MRI is superior in identification of occult carpal fracture, but is not always accessible. An AI tool to aide clinical diagnosis of occult carpal fractures using x-rays would increase diagnostic sensitivity in areas and situations where MRI is not available.  |
+| <b>Modality</b> | X-ray |
+| <b>Pathology</b> | Occult carpal fractures (wrists and hands) |
+| <b>Description</b> | A computer aided diagnosis tool which would automatically run when either a scaphoid fracture is suspected or if a patient is referred for a hand/wrist x-ray from A&E would increase sensitivity and confidence of diagnosis. Carpal fractures can be difficult to identify and patients with high clinical suspicion are put in a splint and referred to the fracture clinic even if a fracture isn’t seen on the x-ray by the clinician. Subtle lucency of an un-displaced fracture and the significance of a small bone fragment is currently easily missed. A successful tool would therefore increase diagnostic confidence and accuracy and reduce repeated x-rays and needless fracture clinic referrals. |
+| <b>Patient pathway</b> | A&E attendance with a suspected scaphoid fracture or hand/wrist injury. |
+| <b>Training datasets</b> | Patient cohort identified using CogStack looking for phrases 'scaphoid' and 'MRI clinical'. The query generated a list of approximately 1000 patients who have had an MRI, with the view that all patients who had an MRI will also have had an x-ray. The patient list is now being stratified to `test`, `control` and `back-up` groups. |
+| <b>Consequences of errors</b> | Needless referrals to fracture clinic and needless immobilisation in patients who do not have a fracture; repeated x-rays; referrals to MRI. |
+| <b>Goals</b> | An automated computer aided diagnosis tool triggered when appropriate x-rays are taken. |
+| <b>Criteria for success</b> | Improvement in diagnostic accuracy and diagnostic speed. |
+| <b>Commercial products available</b> | <a href="http://www.gleamer.ai/">Gleamer</a>, which specialise in trauma x-rays, has been considered for this purpose but was decided not suitable to solve this particular clinical problem. The decision was made to train an in-house algorithm instead. |
+| <b>Other considerations</b> | Suboptimal views are difficult to interpret. Background of arthritis can make small fractures difficult to see. |
+| <b>Project Plan</b> | <strike>1.	Meeting of all persons involved to determine AI specifications. <br><br> 2.	Setting technical and system requirements for AI model. </strike> <br> <br> 3. Dataset curation (retrospective). <br><br> 4.	Model training<br><br>5.	Model testing <br><br>6.	Implementation <br><br>7. Audit|
+| <b>References</b> | <a href="https://online.boneandjoint.org.uk/doi/full/10.1302/0301-620X.101B8.BJJ-2018-1590.R1"> TOHETI trial results </a> |

--- a/_projects/AIC003-osteoporosis.md
+++ b/_projects/AIC003-osteoporosis.md
@@ -1,0 +1,37 @@
+---
+layout: ourwork
+title: Osteoporosis
+status: Contracting
+image: /assets/img/blog/nhs_logo.png
+summary: This is a project summary.
+csc-lead:
+modality:
+pathology:
+rationale:
+patient-pathway: 
+training-data: 
+errors: 
+goals: 
+success-criteria: 
+alternatives: 
+---
+
+
+# **Osteoporosis**
+
+| <b>Project Title</b> | Cross modality identification of vertebral compression fractures in the identification of background population osteoporosis |
+| <b>Clinical lead(s)</b> |  |
+| <b>CSC lead</b> | [Dika](/team/dika.md) |
+| <b>AI Centre Number</b> | AIC003 |
+| <b>Rationale</b> | 77% of scans with vertebral compression fractures are correctly identified and 43% scans recommend referrals – both of these numbers can be improved with AI tool. |
+| <b>Modality</b> | CT first, then x-ray, then MRI. |
+| <b>Pathology</b> | Vertebral compression fractures (spine) |
+| <b>Description</b> | Background osteoporosis is easily treatable if identified, but can lead to complex fractures at other sites if undiagnosed, especially in the hip where a > 50% mortality at 12 months over the age of 80. Currently, 70% of vertebral compression fractures are undiagnosed though they are the most common osteoporotic fracture. This project would work in conjunction with the current fracture liaison service quality improvement project. |
+| <b>Patient pathway</b> | Incidental findings, patients present for imaging for other reasons. |
+| <b>Training datasets</b> | Clinical datasets are available (CT, MRI, x-rays). Imaging usually performed for other indications. |
+| <b>Consequences of errors</b> | A timely identification of vertebral compression fractures which indicate osteoporosis allows the clinicians to refer the patient for osteoporosis treatment. If the osteoporosis signs are missed and the patient sustains a fracture, the fracture is complex and carries a high rate of mortality in older patients. |
+| <b>Goals</b> | Increased rates of identification and treatment referrals after identification to reduce occurrence of complex fractures in other sites. |
+| <b>Criteria for success</b> | Increased referrals and identifications of vertebral compression fractures. |
+| <b>Commercial products available</b> | <a href="https://www.zebra-med.com/bone-health-solution"> ZebraMed</a>. Retrospective and prospective trials are planned to take place in the early 2021. The results will determine whether this clinical problem will be solved with ZebraMed's BoneHealth solution. |
+| <b>Project Plan</b> | <strike>1.	Meeting of all persons involved to determine AI specifications.</strike> <br><br> 2.	Agreeing on technical specifications, success criteria and evaluation plan. <br> <br> 3. Dataset curation (retrospective) -- approximately 1000 CTs with spine in field of view, patients > 55 years. Cogstack to be used for cohort selection. <br><br> 4.	Retrospective evaluation (3 weeks, 1000 scans)<br><br>5.	Prospective evaluation live in clinic (2 months) <br><br>6.	Analysis of evaluation results: if successful, then procurement, if unsuccessful, change strategy. After the completion of CTs, we will move on to solve the same problems using other modalities. <br><br>7. Audit|
+| <b>References</b> | <a href="https://research-information.bris.ac.uk/ws/portalfiles/portal/282788915/1759720x211024029.pdf">Opportunistic diagnosis of osteoporosis, fragile bone strength and vertebral fractures from routine CT scans; a review of approved technology systems and pathways to implementation: a Review of Approved Technology Systems and Pathways to Implementation.</a> |

--- a/_projects/AIC004_IncidentalFindingPE_CT.md
+++ b/_projects/AIC004_IncidentalFindingPE_CT.md
@@ -1,0 +1,36 @@
+---
+layout: ourwork
+title: Incidental Pulmonary Embolism
+status: Contracting
+image: /assets/img/blog/nhs_logo.png
+summary: This is a project summary.
+csc-lead:
+modality:
+pathology:
+rationale:
+patient-pathway: 
+training-data: 
+errors: 
+goals: 
+success-criteria: 
+alternatives: 
+---
+
+
+# **Incidental pulmonary embolism (PE)**
+
+| <b>Project Title</b> | Role of AI in detection of incidental Pulmonary Emboli |
+| <b>Clinical lead(s)</b> | TBC |
+| <b>CSC lead</b> | [Simone](/team/Simone.html) |
+| <b>Rationale</b> | Incidental findings of Pulmonary Emboli on routine cancer surveillance CT scans with contrast agent(Thorax/Abdomen/Pelvis)  |
+| <b>Modality</b> | Contrast enhanced CT (Thorax/Abdomen/Pelvis)  |
+| <b>Pathology</b> | Pulmonary Emboli (Incidental Findings)|
+| <b>Description</b> | A computer aided diagnosis tool which supports the clinician for the detection of incidental Pulmonary Emboli during cancer follow up exams. Contrast enhanced CT scans (Thorax, Pelvis, Abdomen) are routinely performed on cancer surveillance and provide the ideal contrast to detect PE. GSTT has currently 7-14 days turn-around timescale for reporting CTs, with the risk that the pathology progresses causing morbidity or mortality. The tool will support identification and prioritisation of the scans, reducing delayed diagnosis and enabling earlier intervention |
+| <b>Patient pathway</b> | Contrast Enhanced CT scans as follow up on cancer patients |
+| <b>Training datasets</b> | Commercial product to be evaluated  |
+| <b>Consequences of errors</b> | Morbidity or mortality if treatment is delayed |
+| <b>Goals</b> | An automated tool for identifying and prioritising patients with PE |
+| <b>Criteria for success</b> | Earlier identification of the pathology and prompt intervention |
+| <b>Commercial products available</b> | <a href="https://www.aidoc.com/"> AIDOC </a> |
+| <b>Project Plan</b> | 1.	Meeting of all persons involved to determine AI specifications. <br><br> 2.	Setting technical and system requirements for AI model. <br> <br> 3. Dataset curation (retrospective). <br><br> 4.	Model training<br><br>5.	Model testing <br><br>6.	Implementation <br><br>7. Audit |
+| <b>References</b> | <a href="https://doi.org/10.3390/app10082945"> Cano-Espinosa et al 2020 </a> <br>  <a href="https://doi.org/10.1007/s00330-020-06998-0"> Wikert et al 2020 </a> <br>  <a href="https://doi.org/10.1038/s41746-020-0266-y"> Huang et al 2020 </a> |

--- a/_projects/AIC005-occult_carpal_detection_in_mri.md
+++ b/_projects/AIC005-occult_carpal_detection_in_mri.md
@@ -1,0 +1,37 @@
+---
+layout: ourwork
+title: Occult Carpal Detection in MRI
+status: Backlog
+image: /assets/img/blog/nhs_logo.png
+summary: This is a project summary.
+csc-lead:
+modality:
+pathology:
+rationale:
+patient-pathway: 
+training-data: 
+errors: 
+goals: 
+success-criteria: 
+alternatives: 
+---
+
+# **Fracture - Occult Carpal Detection in MRI -- Next Steps post TOHETI**
+
+| Project Title | Fracture - Occult Carpal Detection in MRI -- Next Steps post TOHETI |
+| Clinical lead(s) | - |
+| <b>CSC lead</b> | [Laurence](/team/laurence.html) |
+| AI Centre Number | AIC005 |
+| Rationale | Scaphoid and occult carpal fractures can be difficult to identify in MR images, typically requiring specialist radiologists that are not always available. This project aims to develop an AI application that can automatically identify these fractures.  |
+| Modality | MRI |
+| Pathology | Occult carpal fracture |
+| Description | Scaphoid and Occult carpal fractures are a significant economic burden on society and the TOHETI study demonstrated economic advantages of primary scanning with short sequence MRI. We aim to develop an AI application to interpret MRI to increase sensitivity and confidence of diagnosis. This should enable rapid turnaround treatment and discharge of these patients, many of whom are treated unnecessarily. If applied this is likely to benefit communities where there are fewer radiologists available for image interpretation and allow triage of reporting. |
+| Patient pathway | Patients with suspected scaphoid or occult carpal fracture are given an x-ray in A&E, if practitioner cannot identify a fracture patient is referred for MRI.  |
+| Training datasets | The TOHETI demographic of patients who were scanned over 2 years would be available. Dataset (held by Tiago Rua, the health technology analyst) of patients who attended A&E with suspected scaphoid fracture (n=67) have an MRI as well as an x-ray. |
+| Consequences of errors | Needless referrals to fracture clinic and needless immobilisation in patients who do not have a fracture; possibility of repeated x-rays and referrals to MRI. |
+| Goals | An automated computer aided diagnosis tool triggered when appropriate MRI data are received able to streamline the workflow and enable faster reads of scans. |
+| Criteria for success | Improvement in diagnostic accuracy and diagnostic speed. |
+| Commercial products available | None currently identified |
+| Project Plan | 1.	Meeting of all persons involved to determine AI specifications <br><br> 2.	Setting technical and system requirements for AI model <br><br> 3.Dataset curation (retrospective) <br><br> 4.Model training <br><br>   5.Model testing<br><br>6.	Implementation|
+| References | - |
+

--- a/_projects/AIC006-rotational-profiles.md
+++ b/_projects/AIC006-rotational-profiles.md
@@ -1,0 +1,35 @@
+---
+layout: ourwork
+title: Rotational Profiles
+status: Scoping
+image: /assets/img/blog/nhs_logo.png
+summary: This is a project summary.
+csc-lead:
+modality:
+pathology:
+rationale:
+patient-pathway: 
+training-data: 
+errors: 
+goals: 
+success-criteria: 
+alternatives: 
+---
+
+# **Rotational profiles**
+
+| <b>Project Title</b> | Assessment of rotational profiles in lower limb CT for pre surgical assessment |
+| <b>Clinical lead(s)</b> | Dr. Christopher Tang  |
+| <b>CSC lead</b> | [Anil](/team/Anil.html) |
+| <b>Rationale</b> | Assessment of rotational profiles is time consuming and complex. An AI algorithm would significantly decrease the amount of time needed to measure the angles of rotation. |
+| <b>Modality</b> | CT |
+| <b>Pathology</b> | Lower limb rotation |
+| <b>Description</b> | Current practice of manually drawing lines over the long bones and the joints on CT images in PACS to figure the degree of misalignment is time-consuming (15-20 minutes per case). An AI tool would automatically create these lines and angles, saving time and reducing variability. |
+| <b>Patient pathway</b> | Patients are referred by the orthopaedic team. CT imaging is part of the pre-surgical work up. The report is used to plan the surgical intervention. |
+| <b>Training datasets</b> | Over 100 patients are referred annually. The data will be retrospective, acquiring a large cohort of patients and segmentation and profile results as annotated on PACS. It is possible annotations will need to be re-done if they cannot be exported from PACS. |
+| <b>Consequences of errors</b> | The tool is to help find the accurate rotational profile and will be supervised and signed off by the radiologist, so an error is unlikely to persist far enough to affect a patient. |
+| <b>Goals</b> | Reduction of radiologist time in reporting these scans as well as increase consistency in calculation. |
+| <b>Criteria for success</b> | Accurate, automated rotational profiles. |
+| <b>Commercial products available</b> | N/A |
+| <b>Project Plan</b> | <b> 1.	Meeting of all persons involved to determine AI specifications.</b> <br><br> For radiologist (Chris) :<br> - [ ] Confirm +/3 to 5 degree precision with peers<br> - [ ] Confirm with surgeons how angles are used to guide knee surgery <br> - [ ] Confirm 3 bone ankle slice is the correct slice to analyse.<br>- [ ]   Review software requirements spec <br> <br><b>2.	Setting technical and system requirements for AI model.</b><br><br> For CSC (Anil) <br>  - [ ]  Perform the risk assessment<br> - [ ] Create software design spec from software requirements spec <br> - [ ] Attempt to build non-A.I software with “dicom_server” and eventually “AI Deployment Engine” <br> - [ ] Investigate the AI route<br><br><b> 3. Dataset curation (retrospective). </b><br><br> - [ ] Collect Patient ID’s for 100-200 patients, analysed by different radiologists<br><br> <b>4.	Model training</b><br><br> <b>5.	Model testing</b> <br><br><b>6.	Implementation</b> <br><br><b>7. Audit </b> |
+| <b>References</b> | Website used to help calculate rotational angles is <a href="http://uwmsk.org/legrotation.html"> here</a>. |

--- a/_projects/AIC008-detection-of-early-rectal-cancers-polyps.md
+++ b/_projects/AIC008-detection-of-early-rectal-cancers-polyps.md
@@ -1,0 +1,77 @@
+---
+layout: ourwork
+title: Early detection of rectal cancer
+status: Scoping
+image: /assets/img/blog/nhs_logo.png
+summary: This is a project summary.
+csc-lead:
+modality:
+pathology:
+rationale:
+patient-pathway: 
+training-data: 
+errors: 
+goals: 
+success-criteria: 
+alternatives: 
+---
+
+# **Early detection of rectal cancer**
+
+| <b>Project Title</b> | A machine learning algorithm to aid in the detection of early rectal cancers/polyps.  |
+| <b>Clinical lead(s)</b> | Tina Mistry |
+| <b>CSC lead</b> | [Laurence Jackson](/team.html) |
+| <b>Rationale</b> | Development of an AI tool to identify areas of concern that may indicate early development of cancer and polyps in rectal MRI images |
+| <b>Modality</b> | MRI |
+| <b>Pathology</b> | Rectal cancer/polyps |
+| <b>Description</b> | MRI pelvis studies are reported by a variety of subspecialty radiologists leading to missed pathology in the rectum outside of the reporter’s immediate comfort zone. The consequence of a missed polyp is the development of later stage cancerous lesions which are more symptomatic and potentially incurable or require extensive surgery/treatment as oppose to minimally invasive endoluminal procedures. An artificial intelligent algorithm has the potential to reduce these errors by highlighting areas of concern particularly within the rectum which can be a challenging area to assess. |
+| <b>Patient pathway</b> | Once a lesion is identified whether these abnormalities are cancerous or polyps the ultimate treatment for this is removal which is curable if performed early. |
+| <b>Training datasets</b> | Large MRI pelvis dataset within the trust with the T2 weighted axial and diffusion performed in most cases. This will give a high yield of normal. Rectal cancer datasets also collected via a recent audit. |
+| <b>Consequences of errors | False positives will either result in early interval repeat imaging or proctoscopy performed by surgeons in clinic/endoscopy. False negative may result in cancers being detected at a later stage. |
+| <b>Goals</b> | An application that is able to identify areas of concern for further analysis by radiologists |
+| <b>Criteria for success</b> | Ability to identify lesions incidentally/early leading to improved outcomes for patients, early detection leads to stopping/reducing the development of malignancy which can be fatal when diagnosed at a late stage. |
+| <b>Commercial products available</b> | None identified |
+| <b>References</b> | [1] Lee, Joohyung, et al. "Reducing the model variance of a rectal cancer segmentation network." IEEE Access 7 (2019): 182725-182733. [online](https://arxiv.org/pdf/1901.07213.pdf) |
+
+___
+
+*The plan below aims to outline the expected outcomes for each stage of the project development cycle.*
+### Project Plan
+**Planning phase**
+1. Meeting of all persons involved to determine AI specifications
+    1. Agree project plan
+    2. Setting technical and system requirements for AI model
+    3. Agree on most useful metrics for success – e.g. percentage reduction in missed polyps
+        * step change in number of reported polyps
+        * This will require designing a fixed methodology for measuring currently missed polyps which can be performed before and after model deployment.
+    4. Agree on minimum valuable requirements for success e.g. 25% reduction in missed polyps
+        * We are aiming for a 10% reduction in missed polyps using the methodology above.
+    5. Agree on size of POC and production datasets and who is responsible for compiling them
+        * We will use existing database of 5 year audit to generate proof-of-concept dataset
+    6. Agree on how model will be deployed
+        * The application will push information back to radiologist workstation to indicate suspect dicom series as well as slice number and region
+
+**Development phase (proof of concept (POC))**
+2. Dataset curation (retrospective)
+    1. Compile POC dataset
+3. Model training
+    1. Produce effective POC model
+4. Model testing
+    1. Test model against agreed criteria for success (where applicable)
+    2. Agreement to continue to production phase OR iterative/improve model OR discontinue
+
+**Development phase (production)**
+5. Dataset curation (retrospective)
+    1. Compile larger production dataset with all appropriate data properties (e.g. ethnicity, weight etc)
+6. Model training
+    1. Produce effective deployment model
+7. Model testing
+    1. Test model against agreed criteria for success (where applicable)
+    2. Clinical approval for model to be deployed
+
+**Deployment phase**
+8. Deployment to test environment (if applicable)
+    1. Testing successful
+9. Deployment to hospital systems
+    1. Training for users
+    2. Continuous monitoring of model performance

--- a/_projects/AIC010-adrenal-adenomas.md
+++ b/_projects/AIC010-adrenal-adenomas.md
@@ -1,0 +1,35 @@
+---
+layout: ourwork
+title: Characterising Adrenal Adenomas
+status: Backlog
+image: /assets/img/blog/nhs_logo.png
+summary: This is a project summary.
+csc-lead:
+modality:
+pathology:
+rationale:
+patient-pathway: 
+training-data: 
+errors: 
+goals: 
+success-criteria: 
+alternatives: 
+---
+
+# **Characterising adrenal adenomas**
+
+| <b>Project Title</b> | The use of AI in characterising incidental adrenal lesions on portovenous CT abdomen and pelvis |
+| <b>Clinical lead(s)</b> |  |
+| <b>CSC lead</b> | [Dika](/team/dika.html) |
+| <b>Rationale</b> | Incidental findings of adrenal lesions occur relatively frequently in CT. Differentiation of the nature of these lesions would help reduce patient recall for further imaging. |
+| <b>Modality</b> | CT |
+| <b>Pathology</b> | Incidentally found adrenal lesions |
+| <b>Description</b> | Within increasing accessibility and demand for CT imaging in radiology, the number of incidental findings are also increasing. The incidence of incidental adrenal lesions is in the region of 5%-10% (from published studies). The challenge for radiologists is giving an accurate diagnosis/characterisation of these adrenal lesions that do not clearly demonstrate macroscopic fat. Hence we often have to recall patients for dedicated adrenal CT examinations. If we are able to use AI technology to better characterise incidental adrenal lesions as either benign, malignant or indermintate, we will reduce our recall rates of patients. |
+| <b>Patient pathway</b> | This project investigates incidental findings so the patient pathways vary. |
+| <b>Training datasets</b> | Retrospective CT contrast images acquired over the last 10 years with confirmed adenoma and confirmed non-adenoma. 100 scans of each are needed in first instance. |
+| <b>Consequences of errors</b> | The aim of this tool is to reduce call back for further imaging in cases of incidental findings. |
+| <b>Goals</b> | A CAD AI tool used on trigger by radiologist which outputs the following parameters: adenoma or non-adenoma? Then charactrise location, volume, and flag for probability of malignancy (low, medium, high). Secondary goals include information on growth on serial imaging and further characterisation of non-adenomas. |
+| <b>Criteria for success</b> | Accurate characterisation of adrenal lesions as adenoma or non-adenoma. |
+| <b>Commercial products available</b> | N/A |
+| <b>Project Plan</b> | 1. Meeting of all persons involved to determine AI specifications. <br><br> 2.	Setting technical and system requirements for AI model. <br> <br> 3. Dataset curation (retrospective). <br><br> 4.	Model training<br><br>5.	Model testing <br><br>6.	Implementation <br><br>7. Audit |
+| <b>References</b> | N/A |

--- a/_projects/AIC012-radiomic-features-from-lung-cancer.md
+++ b/_projects/AIC012-radiomic-features-from-lung-cancer.md
@@ -1,0 +1,35 @@
+---
+layout: ourwork
+title: Radiomic features from CT to predict lung cancer
+status: Backlog
+image: /assets/img/blog/nhs_logo.png
+summary: This is a project summary.
+csc-lead:
+modality:
+pathology:
+rationale:
+patient-pathway: 
+training-data: 
+errors: 
+goals: 
+success-criteria: 
+alternatives: 
+---
+
+# **Radiomic features from CT to predict lung cancer**
+
+| <b>Project Title</b> | AI to extract Radiomic Features from CT images as non-invasive tool to predict outcome of patients with lung cancer|
+| <b>Clinical lead(s)</b> |  |
+| <b>CSC lead</b> | [Anil](/team/anil.html) |
+| <b>Rationale</b> | Radiomic Features (RF) that are extracted from contrast enhanced CT of lung cancer and lymph nodes can be correlated with histology and survival outcomes to provide a non-invasive predictive tool to develop a multi-parametric predictive model to assistive the decisions in patient treatment.   |
+| <b>Modality</b> | Thorax CT (contrast enhanced)|
+| <b>Pathology</b> | Lung cancer with nodal involvement |
+| <b>Description</b> |   The survival rates from non-small-cell lung cancer is associated with TNM grading system (tumour, nodal involvement and metastatic extent), and also protein expression, however the only way to evaluate both is using histology results from an invasive biopsy investigation. Biopsies are also limited in that they may not fully character the tumour and spread of disease. The aim of this project is to use AI to extract RFs from the lymph nodes and lung cancer and correlate them with histology, to assess the RF ability to predict histology and patient outcomes. This will result in a non-invasive tool to build multivariate predictive models and stratify patient treatments.    |
+| <b>Patient pathway</b> | Patients receive a contrast enhanced CT then a biopsy for diagnosis and staging of lung cancer, the results of which determine the treatment path.  |
+| <b>Training datasets</b> | Pre-operative Contrast enhanced Thorax CTs (2014-2018), collected into a database (n = 500 ~ 600). Option of including recent CTs (2018 – present) with limited data on survival after surgery.  |
+| <b>Consequences of errors</b> | Poor RF will develop a model with little predictive value. Mismanagement of patient treatment. Poor research outcomes. |
+| <b>Goals</b> | A tool that extracts radiomic features with a high predictive power in predicting histology and patient outcomes. |
+| <b>Criteria for success</b> | Well-segmented primary lung lesions and intrathoracic lymph nodes. This will require clinicians’ supervision and validation against manual segmentation. Also, based on this, subsequent important criteria for AI success within this project will be the ability of RF automatically extracted from images to show correlation with histological parameters and outcome data. |
+| <b>Commercial products available</b> | N/A|
+| <b>Project Plan</b> | 1.	Meeting of all persons involved to determine AI specifications. <br><br> 2.	Setting technical and system requirements for AI model. <br> <br> 3. Dataset curation (retrospective). <br><br> 4.	Model training<br><br>5.	Model testing <br><br>6.	Implementation <br><br>7. Audit|
+| <b>References</b> |  <a href="https://doi.org/10.1016/j.ejrad.2020.109150"> Wang et al 2020 </a> <br> <a href="https://doi.org/10.3390/diagnostics10060359"> Ninatti et al 2020 </a> <br> <a href="https://doi.org/10.1259/bjr.20190159"> Bashir et al 2019 </a> <br>  <a href="https://doi.org/10.1158/1078-0432.ccr-18-2495"> Xu et al 2019 </a> <br> <a href="https://doi.org/10.1016/j.ejca.2011.11.036"> Lambin et al 2012 </a> <br> <a href="https://tlcr.amegroups.com/article/view/12141/10357"> Wilson et al 2017 </a> <br> <a href="https://doi.org/10.3389/fonc.2020.00418"> Xia et al 2019 </a> <br> <a href="https://doi.org/10.1155/2019/1545747"> Weikert et al 2019 </a> <br> <a href="https://doi.org/10.1016/j.lungcan.2020.11.005"> Tsitsias et al 2020 </a> <br>   |

--- a/_projects/AIC013-SPECTCT-prosthetic-loosening.md
+++ b/_projects/AIC013-SPECTCT-prosthetic-loosening.md
@@ -1,0 +1,35 @@
+---
+layout: ourwork
+title: Prosthetic Loosening
+status: Data Curating
+image: /assets/img/blog/nhs_logo.png
+summary: This is a project summary.
+csc-lead:
+modality:
+pathology:
+rationale:
+patient-pathway: 
+training-data: 
+errors: 
+goals: 
+success-criteria: 
+alternatives: 
+---
+
+# **Prosthetic Loosening**
+
+| <b>Project Title</b> | SPECT/CT and evaluation of prosthetic loosening |
+| <b>Clinical lead(s)</b> |  |
+| <b>CSC lead</b> | [Dika](/team/dika.html) |
+| <b>Rationale</b> | Prosthetic loosening is definitively diagnosed with a SPECT/CT. Around 40% of cases are not obvious and in 20% of cases the report is changed with further consultation. An AI tool would help in accuracy and increase confidence in reporting. |
+| <b>Modality</b> | SPECT/CT |
+| <b>Pathology</b> | Prosthetic loosening – mostly hip and knees, occasional elbow and shoulder |
+| <b>Description</b> | Bone scan and SPECT CT are effective ways of assessing loosening as the metal artefact reduces the clarity of other imaging modalities. Patients will also be referred to x-ray and CT, but SPECT/CT supersedes these for accuracy. |
+| <b>Patient pathway</b> | Patients are referred as a result of:<br><br>1 – pain in the replacement site<br>2 – x-ray investigations suggest loosening<br><br>Patients are referred from orthopaedics and surgery to consider replacement of a prosthesis or to revise the replacement. Next steps are decided by SPECT/CT reports. SPECT/CT is also used for surveillance so imaging is repeated in intervals. |
+| <b>Training datasets</b> | 250 patients annually. Data to be gathered retrospectively. |
+| <b>Consequences of errors</b> | When the diagnosis of prosthetic loosening is missed, the patient remains in chronic (severe) pain for a prolonged amount of time. When the diagnosis of prosthetic loosening is incorrect, patient undergoes unnecessary surgery.  |
+| <b>Goals</b> | Reducing patient pain and avoiding unnecessary surgery. Improving diagnosis speed and accuracy.  |
+| <b>Criteria for success</b> | Increased diagnostic accuracy and thus reduction in unnecessary surgery, increase in speed with which loosening is diagnosed. |
+| <b>Commercial products available</b> | N/A |
+| <b>Project Plan</b> | 1.	Meeting of all persons involved to determine AI specifications. <br><br> 2.	Setting technical and system requirements for AI model. <br> <br> 3. Dataset curation (retrospective). <br><br> 4.	Model training<br><br>5.	Model testing <br><br>6.	Implementation <br><br>7. Audit |
+| <b>References</b> |  |

--- a/_projects/AIC015_Carnax_Paediatric_Xray.md
+++ b/_projects/AIC015_Carnax_Paediatric_Xray.md
@@ -1,0 +1,36 @@
+---
+layout: ourwork
+title: Neonatal abdominal X Ray
+status: Developing
+image: /assets/img/blog/nhs_logo.png
+summary: This is a project summary.
+csc-lead:
+modality:
+pathology:
+rationale:
+patient-pathway: 
+training-data: 
+errors: 
+goals: 
+success-criteria: 
+alternatives: 
+---
+
+# **Neonatal abdominal X Ray**
+
+| Project Title | Carnax - computer assisted reporting of neonatal abdominal x rays |
+| <b>Clinical lead(s)</b> | TBC |
+| <b>CSC lead</b> | [Simone](/team/simone.html) |
+| <b>Rationale</b> | AI-based medical imaging tool for detection of intestinal perforation in preterm neonates (abdominal x ray)  |
+| <b>Modality</b> | Abdominal X Ray (Paediatric) |
+| <b>Pathology</b> | Perforation of the intestine in preterm new-born babies |
+| <b>Description</b> | About one in every ten newborn babies requires support on a neonatal unit. Most of these infants are premature (born at less than 37 weeks of pregnancy). Premature infants are at greater risk of intestinal problems which can lead to infection, inflammation or a hole in the wall of the bowel. Clinical teams that look after these babies rely on x-rays of the abdomen to know if there is a problem with a child’s gut. On occasion problems are missed because the x-ray is not looked at carefully enough or because the clinician is tired or inexperienced. A computer algorithm can be trained to recognise abnormalities on an x-ray. This system can then be used to alert the clinical team early if there is a problem. This could prompt earlier treatment and prevent babies from getting sicker |
+| <b>Patient pathway</b> | Routine abdominal X-Ray on preterm newborn babies with suspected bowel perforation |
+| <b>Training datasets</b> | Clinical lead will select images of patients with and without pathology |
+| <b>Consequences of errors</b> | If a perforation is missed or the baby is diagnosed in very late stage, this might imply sickness, cerebral damage and ultimately death |
+| <b>Goals</b> | Recognise abnormalities in abdominal X Ray and notify the consultant radiologist |
+| <b>Criteria for success</b> | Early diagnosis may avoid serious and long-term consequences for the life of a new-born baby |
+| <b>Commercial products available</b> | To the best of our knowledge, there are no commercial products currently available |
+| <b>Other considerations</b> | Perforation is not straightforward to detect, it might be missed by a junior radiologist or if the radiologist is tired |
+| <b>Project Plan</b> | 1.	Meeting of all persons involved to determine AI specifications. <br><br> 2.	Setting technical and system requirements for AI model. <br> <br> 3. Dataset curation (retrospective). <br><br> 4.	Model training<br><br>5.	Model testing <br><br>6.	Implementation <br><br>7. Audit|
+| <b>References</b> | <a href="https://doi.org/10.1038/s41598-020-74653-1"> Kwon et al 2020 </a> |

--- a/_projects/AIC016-synth_ct.md
+++ b/_projects/AIC016-synth_ct.md
@@ -1,0 +1,35 @@
+---
+layout: ourwork
+title: Synthetic CT for MR-Only Prostate Radiotherapy Planning
+status: Evaluating
+image: /assets/img/blog/nhs_logo.png
+summary: This is a project summary.
+csc-lead:
+modality:
+pathology:
+rationale:
+patient-pathway: 
+training-data: 
+errors: 
+goals: 
+success-criteria: 
+alternatives: 
+---
+
+# **Synthetic CT for MR-Only Prostate Radiotherapy Planning**
+
+| Project Title | AI to create a Synthetic CT for MR-Only Prostate Radiotherapy Planning|
+| <b>Clinical lead(s)</b> |  Christopher Thomas|
+| <b>CSC lead</b> | [Anil](/team/anil.html) |
+| <b>Rationale</b> | MRI gives superior soft tissue contrast compared to CT images which allows more accurate contouring of internal organs and tumours for radiotherapy (RT). Only CT images, however, provide the voxel electron density data needed to calculate the dose distribution from radiation beams. Having an MRI with electron density information in the form of a “synthetic CT” (SynCT) would streamline imaging, reduced concomitant imaging dose, and improve contouring tumours and organs, thus reducing unnecessary dose to healthy tissues which is linked to reduced toxicity and complications post-treatment.    |
+| <b>Modality</b> | Radiotherapy CT, MRI|
+| <b>Pathology</b> | T3N0 Prostate Cancer |
+| <b>Description</b> |Patients prescribed radiotherapy to the prostate have a CT scan which provides anatomical information used to target the RT, and electron density info required for dose calculation in the treatment planning system (TPS). The patient’s RT plan is generated using the CT scan and the plan is sent to the treatment machine. Prostate RT patients experience toxicity side-effects due to irradiation of healthy tissues including rectum, bladder, urethra and penile bulb. Doses to these tissues are higher than they could be due to uncertainties in defining the prostate treatment volume on CT, where studies show that delineation of the prostate on MR results in 25-40% reduction in prostate volume [2-5] with more consistency between operators [6-9]. <br><br> An in-house study at GSTT has shown that rectal and bladder dose can be reduced, and this should relate to a reduction in toxicity risk. The improved soft-tissue contrast of MRI can be used to better define targets and additional healthy tissue [10]. Ideally an MR-only pathway is used, where the MRI is used for anatomical delineation and for dose calculation. A benefit of MR-only RT is the removal of registration uncertainties [12] present in a combined CT + MRI pathway. MRI data has no inherent electron density information so for an MR-only pathway to be feasible a SynCT must be made for the TPS dose calculation. <br><br> Funding from the National Institute for Health Research and Social Care (NIHR)  (RP-2-16-07-001) has supported Christopher Thomas during his PhD project which involved generating synthetic CT images from MRI images for prostate radiotherapy patients at Guy’s and St Thomas’s NHS FT. An output of the project is a UNET model that has been trained on registered CT and MRI image sets from 24 patients participating in a clinical trial evaluating MR-Only radiotherapy treatment planning (NCT03238170). This trained model is to be deployed into an MR-only clinical pathway via dicomserver. |
+| <b>Patient pathway</b> | Currently, patients receiving radiotherapy for prostate cancer T3N0 undergo CT imaging, where the patient is in the RT treatment position on an identical treatment couch. If MRI is also required for improved soft tissue delineation, then a RT MRI is acquired at Guys Cancer Centre, with an identical treatment couch. The CT and MRI are both imported into the TPS, registered into the same reference frame, then contoured by the clinician.<br>The proposed project would allow the RT MRIs, generated from a set protocol, to be automatically sent to a ML model (in “dicomserver” or “AI Deployment Engine”) that would generate a SynCT which automatically transfers to a input folder for the treatment planning software. |
+| <b>Training datasets</b> | 35 patients with MR and CT images, pseudonymised, as part of <a href= "https://clinicaltrials.gov/ct2/show/NCT03238170"> clinical trial (NCT03238170)</a>  |
+| <b>Consequences of errors</b> | Dose distributions from the RT treatment plans would be incorrectly calculated which could result in poor treatment efficacy and increase toxicity to healthy tissues.  |
+| <b>Goals</b> | To implement a model that can assign Hounsfield units (related to electron density) to voxels in MR image sets for prostate RT planning, in a way that provide little to no interaction from radiotherapy staff & clinicians.  |
+| <b>Criteria for success</b> | Reduction of healthy tissue dose and toxicity risk in patients receiving RT to the prostate. |
+| <b>Commercial products available</b> | Philips MRCAT (MR for Calculating ATtenuation) <br><br>Siemens syngo.via RT Image Suite|
+| <b>Project Plan</b> | 1.	Meeting of all persons involved to determine AI specifications. <br><br> 2.	Setting technical and system requirements for AI model. <br> <br> 3. Dataset curation (retrospective). <br><br> 4.	Model training<br><br>5.	Model testing <br><br>6.	Implementation <br><br>7. Audit|
+| <b>References</b> | [1] <a href=" https://www.cancerresearchuk.org/health-professional/cancer-statistics/statistics-by-cancer-type/prostate-cancer" > CRUK prostate Cancer Statistics</a><br>[2] <a href = "https://doi.org/10.1016/s0360-3016(98)00351-4"> Rasch et al. 1997</a><br>[3] <a href = "https://doi.org/10.1259/bjr.75.895.750603"> Sannazzari et al. 2014</a><br>[4] <a href = "https://doi.org/10.1016/0360-3016(96)00232-5"> Roach et al. 1996</a><br>[5] <a href = "https://doi.org/10.1016/s0360-3016(96)00620-7"> Kagawa et al. 1997</a><br>[6] <a href = "https://doi.org/10.1016/s0360-3016(99)00288-6" > Debois et al. 1999 </a><br>[7]<a href = "https://doi.org/10.1016/s0167-8140(02)00407-3"> Parker et al. 2003 </a><br>[8]<a href = "https://doi.org/10.1259/bjr.20180948"> Pathmanathan et al. 2019</a><br>[9]<a href = "https://doi.org/10.1016/j.ijrobp.2010.03.019"> Usmani et al. 2011</a><br>[10]<a href = "https://doi.org/10.1186/1748-717x-7-82"> Vainshtein et al. 2021</a><br>[11]<a href = "https://doi.org/10.1016/j.rcl.2017.10.012"> Menard et al. 2018</a><br>[12]<a href = "https://doi.org/10.1186/1748-717x-4-54"> Nyholm et al. 2009</a><br>[13]<a href = "https://doi.org/10.1016/j.ijrobp.2017.08.043"> Johnstone et al. 2018</a><br>[14]<a href = "https://doi.org/10.1016/S0167-8140(21)01769-2"> Thomas et al. 2020</a><br>[15]<a href = "https://doi.org/10.1016/j.ijrobp.2019.06.2530"> Bird et al. 2019</a><br>[16]<a href = "https://doi.org/10.1016/j.phro.2019.11.005"> Wyatt et al. 2019</a><br>|

--- a/_projects/AIC017-NLP_endoscopic_resources_optimisation.md
+++ b/_projects/AIC017-NLP_endoscopic_resources_optimisation.md
@@ -1,0 +1,35 @@
+---
+layout: ourwork
+title: NLP for optimisation of endoscopic resources
+status: Data Curating
+image: /assets/img/blog/nhs_logo.png
+summary: This is a project summary.
+csc-lead:
+modality:
+pathology:
+rationale:
+patient-pathway: 
+training-data: 
+errors: 
+goals: 
+success-criteria: 
+alternatives: 
+---
+
+# **NLP for optimisation of endoscopic resources**
+
+| Project Title | Natural Language Processing of Endoscopic and associated pathology text to optimise post COVID endoscopy resources |
+| <b>Clinical lead(s)</b> | Sebastian Zeki |
+| <b>CSC lead</b> | Laurence Jackson(/team.html) |
+| <b>Rationale</b> | Patients with premalignant disease of the upper gastrointestinal tract need to undergo regular endoscopic surveillance to prevent malignancy. The timing of endoscopic procedures is often inaccurate and many patients are either surveyed endoscopically late or inappropriately which becomes a healthcare resource burden. Using natural language processing to automatically caluclate follow up timings based on information in the EPR system |
+| <b>Modality</b> | Endoscopy, EPR|
+| <b>Pathology</b> | Premalignant disease of the upper gastrointestinal tract |
+| <b>Description</b> | The current COVID pandemic has lengthened the waiting list for endoscopic surveillance for premalignant disease such that some patients may develop malignancy whilst waiting for endoscopy. Similarly, by booking follow up endoscopy too early for patients, scarce healthcare resources are being used inappropriately. This risk could be offset by a rigorous guideline based assessment of patients on the waiting list for assessment so that patients who have been planned to be endoscoped too early, or inappropriately can be planned more appropriately. To do this endoscopy and pathology free text reports need to be analysed for patients on the waiting list. The decision about the timing of follow up endoscopy depends on the natural language information contained within both sets of reports. Because of the number of patients, the aim of the current study is to automate the analysis using natural language processing. |
+| <b>Patient pathway</b> | The model will interpret endoscopy notes to determine the most appropriate follow up booking date. The practical output would be a spreadsheet containing the endoscopy and associated pathology report along with the extracted information of interest and a suggested follow up timing. In the first instance the spreadsheet would be passed to a manual vetter as a final check on the output prior to bookings being made |
+| <b>Training datasets</b> | Endoscopy and Pathology reports from EPR. Synthetic dataset used to date for proof of concept. |
+| <b>Consequences of errors</b> | Patient may be given inappropriately early/late follow up exam |
+| <b>Goals</b> | Optimise available endoscopy resources by refining booking process for patient follow up exams |
+| <b>Criteria for success</b> | 1. Reduction in the number of endoscopies done inappropriately early. <br><br> 2. Reduction in the number of endoscopies performed too late (?with decrease in missed early cancer rate). <br><br> 3.	Reduction in patients lost to follow up |
+| <b>Commercial products available</b> | None identified |
+| <b>Project Plan</b> | 1.	Meeting of all persons involved to determine AI specifications. <br><br> 2.	Setting technical and system requirements for AI model. <br> <br> 3. Dataset curation (retrospective). <br><br> 4.	Model training<br><br>5.	Model testing <br><br>6.	Implementation <br><br>7. Audit |
+| <b>References</b> | - |

--- a/_projects/project-template.md
+++ b/_projects/project-template.md
@@ -1,0 +1,19 @@
+---
+layout: ourwork
+title: Project Title
+status:
+image: /assets/img/blog/nhs_logo.png
+summary: This is a project summary.
+csc-lead:
+modality:
+pathology:
+rationale:
+patient-pathway: 
+training-data: 
+errors: 
+goals: 
+success-criteria: 
+alternatives: 
+---
+
+Project text.

--- a/ourwork.md
+++ b/ourwork.md
@@ -1,23 +1,19 @@
 ---
-layout: ourwork
-title: Our Work
+layout: project_board
+title: Projects
 ---
 
-## Our Work
+The Project Board below tracks the progress of each CSC project through the different 
+phases of the software developmental lifecycle. 
 
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. At, blanditiis, eos fugit in magni modi nemo quaerat quis repudiandae sunt vero voluptatum! Accusantium alias deleniti deserunt, dolores earum eligendi, eum illo iusto minima minus nam numquam quos sint tempora ullam ut vitae. Cumque doloremque error, ipsam iusto minima molestiae quam?</p>
-
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. A aliquam architecto assumenda consequuntur, earum explicabo, harum, minus nam porro quisquam recusandae sit voluptates! Aperiam beatae consequuntur dolorum minima optio temporibus!</p>
-
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ad adipisci animi, asperiores autem consectetur deserunt dolor eum eveniet excepturi fuga hic maxime omnis quaerat quibusdam, quis sunt veniam voluptatibus? Accusamus assumenda atque consequuntur culpa cumque dolorum ea eligendi error ex excepturi fugiat in iusto magni nesciunt, non odio optio placeat porro quam repellendus sed, sint veritatis voluptatum. Asperiores distinctio dolorem ducimus illo in itaque maxime non officia omnis, perspiciatis quo.</p>
-
-### Subtitle: The second
-
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab assumenda ipsam libero tempore voluptate. Adipisci, atque consectetur dolor dolorum esse in nemo neque nobis omnis recusandae! Fuga itaque laboriosam nam nostrum officiis unde velit voluptatem. Adipisci blanditiis dignissimos impedit iusto nam quidem sed similique temporibus!</p>
-
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. A ad aliquid debitis ducimus eum modi nam quidem, repellat rerum soluta.</p>
-
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquid at consectetur consequatur corporis cupiditate, eaque eligendi excepturi exercitationem fugit, id impedit inventore ipsam maxime minima modi nemo nobis obcaecati perspiciatis porro praesentium quos recusandae rerum sunt suscipit tenetur vero voluptatem.</p>
-
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquid asperiores est exercitationem fuga fugit hic laudantium magni maxime molestiae necessitatibus neque obcaecati, pariatur praesentium repudiandae, sunt. A alias beatae, deserunt dignissimos ea explicabo fugiat in ipsa iste libero natus perspiciatis quas, quasi recusandae rem sequi tempora. Dolorem hic provident reprehenderit sunt! Blanditiis deserunt eligendi laboriosam quibusdam quos rerum ullam, voluptatibus.</p>
-
+These stages are:
+- **Backlog**:
+- **Scoping**: 
+- **Documenting**:
+- **Governance**:
+- **Contracting**:
+- **Data Curating**:
+- **Developing**:
+- **Evaluating**:
+- **Reporting**:
+- **Graveyard**:


### PR DESCRIPTION
This PR adds Project Board to the website, which replaces the old Kanban Board.

The Projects each have an associated .md file in the `_projects` folder. The frontmatter in the .md files is used in the Project Cards and also the project pages when the user clicks through each card.

TODO:
- Project Board looks odd if there are no cards in a certain section, therefore create a "No projects in this section" message.
- All the projects need updating as they are out of date
- All projects need an associated image
- Text in Project Board page intro area needs completing
- @lucy-funnell to go through Projects and make sure they are in correct sections, update as necessary, etc.