### PR TITLE
updated link map to new image size

### DIFF
--- a/_layouts/platforms.html
+++ b/_layouts/platforms.html
@@ -26,12 +26,12 @@ document.getElementById("page-top").className="bg-light";
         <img src="assets/img/platforms/platforms-wheel.png" class="w-50" usemap="#workmap">
     </div>
 
-    <map name="workmap">
-        <area shape="rect" coords="450,200,480,300" alt="Computer" href="/platforms/flip.html">
-        <area shape="rect" coords="500,250,700,350" alt="Computer" href="/platforms/mlops.html">
-        <area shape="rect" coords="90,400,250,500" alt="Computer" href="/platforms/aide.html">
-        <area shape="rect" coords="110,90,220,180" alt="Computer" href="/platforms/cogstack.html">
-        <area shape="rect" coords="220,20,310,70" alt="Computer" href="/platforms/xnat.html">
+ <map name="workmap">
+        <area shape="rect" coords="430,280,460,330" alt="Computer" href="/platforms/flip.html">
+        <area shape="rect" coords="400,440,480,500" alt="Computer" href="/platforms/mlops.html">
+        <area shape="rect" coords="130,400,200,440" alt="Computer" href="/platforms/aide.html">
+        <area shape="rect" coords="180,110,280,140" alt="Computer" href="/platforms/cogstack.html">
+        <area shape="rect" coords="300,70,370,100" alt="Computer" href="/platforms/xnat.html">
     </map>
 
     <!--Landscape Grid-->


### PR DESCRIPTION
#89 since we changed the landscape wheel image, the link map had be changed to the new image locations. That has now been done.