### PR TITLE
added clarity booking info to NHS admin

### DIFF
--- a/_handbook/nhs_admin.md
+++ b/_handbook/nhs_admin.md
@@ -19,7 +19,7 @@ More information about the PDR process can be found on the Trust HR Portal.
 
 **Clarity Booking System**
 
-When booking Hotels/Flights/Train etc this can be done through the Clarity Booking System. This is the site's <a href="https://ctmcrown.sabscorp.com/js/clarity/current/#/logonl">URL</a>.
+When you need to get work travel budget authorized and paid for by the NHS, the first step is to email Haris for authorisation. The next step is to book it throught the <a href="https://ctmcrown.sabscorp.com/js/clarity/current/#/logonl"> Clarity Booking System </a>.
 Alternatively, you can contact Clarity both online and offline at:
 Online contacts
 

--- a/_handbook/nhs_admin.md
+++ b/_handbook/nhs_admin.md
@@ -16,3 +16,17 @@ may be required. This is also an opportunity to discuss your career progression,
 changes in working hours.
 
 More information about the PDR process can be found on the Trust HR Portal. 
+
+**Clarity Booking System**
+
+When booking Hotels/Flights/Train etc this can be done through the Clarity Booking System. This is the site's <a href="https://ctmcrown.sabscorp.com/js/clarity/current/#/logonl">URL</a>.
+Alternatively, you can contact Clarity both online and offline at:
+Online contacts
+
+Email – gsttonline@claritybt.com
+Phone - 0333 230 9194
+
+Offline contacts
+
+Email – gstt@claritbt.com
+Phone - 0333 230 9194

--- a/_includes/calendar.html
+++ b/_includes/calendar.html
@@ -12,7 +12,7 @@
   <tbody>
   {% for item in site.data.calendar %}
   <tr>
-    <td>{{ item.date }}</td>
+    <td> {{ item.date }}</td>
     <td>{{ item.title }}</td>
     <td class="d-none d-lg-block">{{ item.description }}</td>
     <td>{{ item.links }}</td>


### PR DESCRIPTION
I have added the clarity booking info under the NHS Admin section of the handbook as per https://github.com/GSTT-CSC/gstt-csc.github.io/issues/134. Let me know if this is where you would expect this info to be stored at.