### PR TITLE
Updates Guides and Handbook page format and content

### DIFF
--- a/_guides/cogstack.md
+++ b/_guides/cogstack.md
@@ -1,8 +1,6 @@
 ---
 title: CogStack
-order: 
-image:
-shorthand: cogstack
+shorthand: CogStack
 ---
 
 

--- a/_guides/hackathon-planning-kit.md
+++ b/_guides/hackathon-planning-kit.md
@@ -1,8 +1,6 @@
 ---
 title: Hackathon Planning Kit
-order: 
-image:
-shorthand: hackathon
+shorthand: Hackathon-Planning
 ---
 
 

--- a/_guides/ndoo.md
+++ b/_guides/ndoo.md
@@ -1,8 +1,6 @@
 ---
 title: National Data Opt-Out (NDOO)
-order: 
-image:
-shorthand: ndoo
+shorthand: NDOO
 ---
 
 The [National Data Opt Out (NDOO)](https://digital.nhs.uk/services/national-data-opt-out) ensures that patients have a right to withdraw their consent to any of their data being used for research or service development, i.e. secondary/indirect care purposes. Therefore, if they do have a recorded opt-out status, their data must therefore be excluded.

--- a/_guides/qips.md
+++ b/_guides/qips.md
@@ -1,8 +1,6 @@
 ---
 title: Quality Improvement Projects (QIPS)
-order: 
-image:
-shorthand: qips
+shorthand: QIPS
 ---
 
 ⚠️ **Before proceeding with the following steps**, please ensure:

--- a/_guides/room_booking.md
+++ b/_guides/room_booking.md
@@ -1,8 +1,6 @@
 ---
 title: Room Booking
-order: 
-image:
-shorthand: roombooking
+shorthand: Room-Booking
 ---
 
 This SOP describes how to book a room in Beckett House, specifically for 5th and 9th floor.

--- a/_guides/xnat.md
+++ b/_guides/xnat.md
@@ -1,8 +1,6 @@
 ---
 title: XNAT
-order: 
-image:
-shorthand: xnat
+shorthand: XNAT
 ---
 
 For the full list of SOPs available for XNAT at Guy's and St Thomas' NHS Foundation Trust (GSTT), please refer to our dedicated XNAT GitHub repository [here](https://github.com/GSTT-CSC/XNAT).

--- a/_handbook/10x_workshops.md
+++ b/_handbook/10x_workshops.md
@@ -2,9 +2,10 @@
 title: 10x Workshops
 category: Ways of Working
 categoryorder: 2
-shorthand: 10x-Workshops
+shorthand: Workshops
 order: 7
 ---
+
 
 <img src="assets/img/handbook/workshop_3.21.jpg" class="img-fluid">
 

--- a/_handbook/10x_workshops.md
+++ b/_handbook/10x_workshops.md
@@ -1,7 +1,9 @@
 ---
 title: 10x Workshops
-order: 8
-image:
+category: Ways of Working
+categoryorder: 2
+shorthand: 10x-Workshops
+order: 7
 ---
 
 <img src="assets/img/handbook/workshop_3.21.jpg" class="img-fluid">

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -1,7 +1,9 @@
 ---
 title: CSC GitHub
-order: 9
-image:
+category: Ways of Working
+categoryorder: 2
+shorthand: CSC-GitHub
+order: 8
 ---
 
 The CSC GitHub can be found here – <a href="https://github.com/GSTT-CSC/">CSC Github</a>.

--- a/_handbook/nhs_admin.md
+++ b/_handbook/nhs_admin.md
@@ -1,32 +1,37 @@
 ---
-title: NHS Admin
-order: 10
-image:
+title: NHS Staff Admin 
+category: Admin 
+categoryorder: 3 
+shorthand: NHS-Staff-Admin 
+order: 9
 ---
-All new members of the CSC team will complete a Trust Induction. Each member will be provided with a GSTT account 
-and corresponding (@gstt.nhs.uk) email address. This will give you access to the Trust's intranet and services including 
-the HR Portal, Service-Now Portal (for IT support) and TrustOLE for completing mandatory training and educational courses.
 
-**PDRs**
+All new members of the CSC team will complete a Trust Corporate Induction, including any upfront training required for their role and primary work site. Each member will be provided with a GSTT account and corresponding GSTT email address e.g., FirstName.LastName@gstt.nhs.uk. This will give you access to the Trust's intranet and services, including the Human Resources (HR) Portal, IT ServiceNow Portal (for IT support), and TrustOLE for completing mandatory training and educational courses.
 
-Each member of the CSC Team undergoes a Performance Development Review (PDR) each year with their Line Manager. This is 
-an opportunity for members of the team to set personal development goals and objectives, reflect on their development 
-and learning from the previous 12 months and highlight any outstanding areas where additional education and/or support 
-may be required. This is also an opportunity to discuss your career progression, health and well-being concerns or 
-changes in working hours.
+#### Remote Working
 
-More information about the PDR process can be found on the Trust HR Portal. 
+The CSC team generally work both remotely within the UK and on-site, with the proportion of time spent in each subject to the nature of work, individual member responsibilities, and Line Manager approval. Generally, in-person attendance at the fortnightly 10x workshops is required but team members may join remotely if necessary.
 
-**Clarity Booking System**
+Remote working overseas, however, is not permitted by the Trust due various tax and legal requirements. 
 
-When you need to get work travel budget authorized and paid for by the NHS, the first step is to email Haris for authorisation. The next step is to book it throught the <a href="https://ctmcrown.sabscorp.com/js/clarity/current/#/logonl"> Clarity Booking System </a>.
-Alternatively, you can contact Clarity both online and offline at:
-Online contacts
+#### Annual Leave
 
-Email – gsttonline@claritybt.com
-Phone - 0333 230 9194
+As per Trust policy, requests for annual leave, as well as other forms of leave, should be raised with your Line Manager for approval.
 
-Offline contacts
+The annual leave balance is renewed in April, and there are certain periods within the UK fiscal year in which you can sell/buy annual leave (see HR Portal for more information) subject to approval. However, if you find you expect to have a remaining unused annual leave balance and do not wish to sell these days, this is typically approved to be carried over into the next fiscal year if it is 5 days or less, whereas more than 5 days will require Line Manager approval. In either case, we recommend you speak to your Line Manager as soon as possible to request formal approval and discuss leave scheduling.
 
-Email – gstt@claritbt.com
-Phone - 0333 230 9194
+#### PDRs
+
+Members of the CSC Team undergo a yearly Performance Development Review (PDR) with their Line Manager, as well as a follow-up mid-year review. This is an opportunity for members of the team to set personal development goals and objectives, reflect on their ongoing progress, and highlight any outstanding areas where additional education and/or support may be required. It is also an opportunity to discuss your career progression, health, and well-being concerns or changes in working hours.
+
+For more information on the PDR process, please refer to the Trust HR Portal.
+
+#### Clarity Booking System
+
+If you require a work travel budget to be authorised and paid for by the NHS, the first step is to email Haris for authorisation. 
+
+Once it has been authorised by Haris, you will then need to book your travel arrangements with Clarity BT by either:
+
+* Their booking system [Clarity Booking System](https://ctmcrown.sabscorp.com/js/clarity/current/#/logonl)
+* Emailing their [online](mailto:gsttonline@claritybt.com) or [offline](mailto:gstt@claritbt.com) support teams
+* Contacting their [online](mailto:gsttonline@claritybt.com) or [offline](mailto:gstt@claritbt.com) support teams by phoning +44 (0)333 230 9194

--- a/_handbook/nhs_admin.md
+++ b/_handbook/nhs_admin.md
@@ -33,5 +33,5 @@ If you require a work travel budget to be authorised and paid for by the NHS, th
 Once it has been authorised by Haris, you will then need to book your travel arrangements with Clarity BT by either:
 
 * Their booking system [Clarity Booking System](https://ctmcrown.sabscorp.com/js/clarity/current/#/logonl)
-* Emailing their [online](mailto:gsttonline@claritybt.com) or [offline](mailto:gstt@claritbt.com) support teams
+* Emailing their online support team at [gsttonline@claritybt.com](mailto:gsttonline@claritybt.com) or offline support team at [gstt@claritbt.com](mailto:gstt@claritbt.com) 
 * Contacting their [online](mailto:gsttonline@claritybt.com) or [offline](mailto:gstt@claritbt.com) support teams by phoning +44 (0)333 230 9194

--- a/_handbook/onboarding.md
+++ b/_handbook/onboarding.md
@@ -1,7 +1,9 @@
 ---
 title: Onboarding
-order: 5
-image:
+category: Admin
+categoryorder: 3
+shorthand: Onboarding
+order: 4
 ---
 
 **Access to Becket House**

--- a/_handbook/our_mission.md
+++ b/_handbook/our_mission.md
@@ -1,7 +1,9 @@
 ---
 title: Our Mission
-order: 2
-image:
+category: Background
+categoryorder: 1
+shorthand: Our-Mission
+order: 1
 ---
 
 The CSC mission statement is: developing people, platforms and policy for digital health. Our objectives are to

--- a/_handbook/our_values.md
+++ b/_handbook/our_values.md
@@ -1,7 +1,9 @@
 ---
 title: Our Values
-order: 3
-image:
+category: Background
+categoryorder: 1
+shorthand: Our-Values
+order: 2
 ---
 
 The CSC team values reflect the values of Guy's and St Thomas' NHS Foundation Trust. Our values are at the heart of 

--- a/_handbook/our_values.md
+++ b/_handbook/our_values.md
@@ -8,9 +8,10 @@ order: 2
 
 The CSC team values reflect the values of Guy's and St Thomas' NHS Foundation Trust. Our values are at the heart of 
 everything we do. They are to:
-- Put patients first
-- Take pride in what we do
-- Respect others
-- Strive to be the best
-- Act with integrity
+
+* Put patients first
+* Take pride in what we do
+* Respect others
+* Strive to be the best
+* Act with integrity
 

--- a/_handbook/qms.md
+++ b/_handbook/qms.md
@@ -1,7 +1,9 @@
 ---
 title: Quality Management System
-order: 7
-image:
+category: Ways of Working
+categoryorder: 2
+shorthand: QMS
+order: 6
 ---
 
 The CSC Quality Management System has been developed in-house and applies to all standalone software medical devices developed by the Clinical Scientific Computing team at Guy's & St Thomas' NHS Foundation Trust.

--- a/_handbook/resources.md
+++ b/_handbook/resources.md
@@ -1,6 +1,8 @@
 ---
 title: Resources
-order: 11
-image:
+category: Resources
+categoryorder: 4
+shorthand: Resources
+order: 10
 ---
 Useful resources, such as software recommendations, links to policy and regulatory documents, and much more can be found here: <a href="resources.html">Resources</a>.

--- a/_handbook/resources.md
+++ b/_handbook/resources.md
@@ -1,8 +1,0 @@
----
-title: Resources
-category: Resources
-categoryorder: 4
-shorthand: Resources
-order: 10
----
-Useful resources, such as software recommendations, links to policy and regulatory documents, and much more can be found here: <a href="resources.html">Resources</a>.

--- a/_handbook/standups.md
+++ b/_handbook/standups.md
@@ -1,7 +1,9 @@
 ---
 title: Standups
-order: 6
-image:
+category: Ways of Working
+categoryorder: 2
+shorthand: Standups
+order: 5
 ---
 
 The CSC Team hosts Standup meetings every **Tuesday and Thursday** from **9.30–10.00am**. 

--- a/_handbook/using_this_handbook.md
+++ b/_handbook/using_this_handbook.md
@@ -1,9 +1,0 @@
----
-title: Using this Handbook
-order: 1
-image:
----
-
-The CSC Handbook is intended to act as an encyclopedia for all activities inside CSC. If you work in CSC,
-if you're new to the CSC Team, if you're a CSC collaborator, or if you're interested in joining CSC then the 
-information you seek should be in here somewhere.

--- a/_handbook/working_in_csc.md
+++ b/_handbook/working_in_csc.md
@@ -1,7 +1,9 @@
 ---
 title: Working in the CSC Team
-order: 4
-image:
+category: Background
+categoryorder: 1
+shorthand: Working-in-CSC
+order: 3
 ---
 
 The CSC Team is small group of individuals from a variety of backgrounds. The team is made up of 7 full time members 

--- a/_handbook/working_in_csc.md
+++ b/_handbook/working_in_csc.md
@@ -21,7 +21,7 @@ pathway. We can support projects of varying sizes and at various stages of the p
 engaged in projects for their entire lifecycle and a CSC member would be assigned to individual projects(as the CSC 
 Lead) to provide a single point of contact clinical leads on the project
 
-The general purpose CSC Team email address is: **cscteam@gstt.nhs.uk**.
+The general purpose CSC Team email address is [cscteam@gstt.nhs.uk](mailto:cscteam@gstt.nhs.uk).
 
 The diagram below illustrates the structure of the CSC Team within Medical Physics at GSTT.
 

--- a/_includes/guides.html
+++ b/_includes/guides.html
@@ -4,16 +4,15 @@
   position: relative;
   /*height: 200px;*/
   overflow: auto;
-}
+}</style>
 
-</style>
 <div class="container-fluid">
     <div class="row">
         <!--  Gets array of _guides/ files and sorts them alphabetically -->
         {% assign items_ordered = site.guides | sort %}
         <div class="col-md-4 col-lg-3 pb-3">
             <div id="scrollspy1" style="background-color: #eee" class="sticky-top">
-                <ul class="nav flex-column nav-pills menu-sidebar" id="guides-navbar" role="tablist">
+                <ul class="nav flex-column nav-pills menu-sidebar" id="navbar" role="tablist">
                     <li class="nav-item">
                         <!--  Adds Home tab at the top which will serve as the base tab -->
                         <a class="nav-link active" id="home-tab" data-toggle="tab" href="#home" role="tab"
@@ -31,32 +30,32 @@
 
         <div class="col-md-8 col-lg-9">
             <div class="tab-content">
-                    <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">
-                        <p>
-                            We've created several guides and standard operating procedures (SOPs), which include
-                            required steps,
-                            our recommended best practices, and helpful bits of information, for use by the team, and
-                            our internal
-                            and external collaborators. Click on the sections in the left-hand sidebar to learn
-                            more.<br><br>
+                <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">
+                    <p>
+                        We've created several guides and standard operating procedures (SOPs), which include
+                        required steps,
+                        our recommended best practices, and helpful bits of information, for use by the team, and
+                        our internal
+                        and external collaborators. Click on the sections in the left-hand sidebar to learn
+                        more.<br><br>
 
-                            These guides are updated as and when necessary, so we recommend both keeping an eye on this
-                            page, as
-                            well as <a href="mailto:CSCTeam@gstt.nhs.uk">reach out to us</a> if you need any further
-                            information.
-                        </p>
-                    </div>
-
-                    {% for item in items_ordered %}
-                    <div class="tab-pane fade" id="{{item.shorthand}}" role="tabpanel"
-                         aria-labelledby="{{item.shorthand}}-tab">
-                       <h3>{{ item.title }}</h3>
-                        <p>{{ item.content }}</p>
-                    </div>
-                    {% endfor %}
+                        These guides are updated as and when necessary, so we recommend both keeping an eye on this
+                        page, as
+                        well as <a href="mailto:CSCTeam@gstt.nhs.uk">reach out to us</a> if you need any further
+                        information.
+                    </p>
                 </div>
+
+                {% for item in items_ordered %}
+                <div class="tab-pane fade" id="{{item.shorthand}}" role="tabpanel"
+                     aria-labelledby="{{item.shorthand}}-tab">
+                    <h3>{{ item.title }}</h3>
+                    <p>{{ item.content }}</p>
+                </div>
+                {% endfor %}
             </div>
         </div>
+    </div>
     <!--  JS scripts which enable deep linking i.e., guides.html#<reference to the specific tab> -->
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
             integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"

--- a/_includes/guides.html
+++ b/_includes/guides.html
@@ -5,45 +5,64 @@
   /*height: 200px;*/
   overflow: auto;
 }
+
 </style>
 <div class="container-fluid">
     <div class="row">
-
-  <!--  Define variable which sorts order of _guides .md files -->
-  {% assign items_ordered = site.guides | sort %}
-
-  <div class="col-md-4 col-lg-3 pb-3">
-    <div id="scrollspy1" style="background-color: #eee" class="sticky-top">
-      <ul class="nav flex-column nav-pills menu-sidebar" id="guidesNav">
-          {% for item in items_ordered  %}
-              <li class="nav-item">
-                <a data-toggle="pill" class="nav-link" href="#guides-entry-{{item.shorthand}}">{{ item.title }}</a>
-              </li>
-          {% endfor %}
-      </ul>
-    </div>
-  </div>
-
-  <div class="col-md-8 col-lg-9">
-      <div class="tab-content">
-          <!-- Default content upon navigation to Guides page and before sections are selected -->
-          <div id="guides-entry-guides" class="tab-pane fade show active">
-              <p>
-                  We've created several guides and standard operating procedures (SOPs), which include required steps,
-                  our recommended best practices, and helpful bits of information, for use by the team, and our internal
-                  and external collaborators. Click on the sections in the left-hand sidebar to learn more.<br><br>
-
-                  These guides are updated as and when necessary, so we recommend both keeping an eye on this page, as
-                  well as <a href="mailto:CSCTeam@gstt.nhs.uk">reach out to us</a> if you need any further information.
-              </p>
-          </div>
-        {% for item in items_ordered %}
-        <div id="guides-entry-{{item.shorthand}}" class="tab-pane fade">
-          <h3>{{ item.title }}</h3>
-          <p>{{ item.content }}</p>
+        <!--  Gets array of _guides/ files and sorts them alphabetically -->
+        {% assign items_ordered = site.guides | sort %}
+        <div class="col-md-4 col-lg-3 pb-3">
+            <div id="scrollspy1" style="background-color: #eee" class="sticky-top">
+                <ul class="nav flex-column nav-pills menu-sidebar" id="guides-navbar" role="tablist">
+                    <li class="nav-item">
+                        <!--  Adds Home tab at the top which will serve as the base tab -->
+                        <a class="nav-link active" id="home-tab" data-toggle="tab" href="#home" role="tab"
+                           aria-controls="home" aria-selected="true">Home</a>
+                    </li>
+                    {% for item in items_ordered %}
+                    <li class="nav-item">
+                        <a class="nav-link" id="{{ item.shorthand }}-tab" data-toggle="tab" href="#{{item.shorthand}}"
+                           role="tab" aria-controls="#{{item.shorthand}}" aria-selected="false">{{ item.title }}</a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
         </div>
-        {% endfor %}
-      </div>
-    </div>
-  </div>
+
+        <div class="col-md-8 col-lg-9">
+            <div class="tab-content">
+                    <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">
+                        <p>
+                            We've created several guides and standard operating procedures (SOPs), which include
+                            required steps,
+                            our recommended best practices, and helpful bits of information, for use by the team, and
+                            our internal
+                            and external collaborators. Click on the sections in the left-hand sidebar to learn
+                            more.<br><br>
+
+                            These guides are updated as and when necessary, so we recommend both keeping an eye on this
+                            page, as
+                            well as <a href="mailto:CSCTeam@gstt.nhs.uk">reach out to us</a> if you need any further
+                            information.
+                        </p>
+                    </div>
+
+                    {% for item in items_ordered %}
+                    <div class="tab-pane fade" id="{{item.shorthand}}" role="tabpanel"
+                         aria-labelledby="{{item.shorthand}}-tab">
+                       <h3>{{ item.title }}</h3>
+                        <p>{{ item.content }}</p>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    <!--  JS scripts which enable deep linking i.e., guides.html#<reference to the specific tab> -->
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+            integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+            crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
+            integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
+            crossorigin="anonymous"></script>
+    <script src="assets/js/deeplinking.js"></script>
 </div>

--- a/_includes/handbook.html
+++ b/_includes/handbook.html
@@ -7,47 +7,55 @@
 }
 </style>
 
-<div class="row">
+<div class="container-fluid">
+    <div class="row">
+        <!--  Gets array of _handbook/ files and sorts them by descending "order" number -->
+        {% assign items_ordered = site.handbook | sort: "order", "last" %}
+        <p> {{ items_shorthands }}</p>
+        <div class="col-md-4 col-lg-3 pb-3">
+            <div id="scrollspy1" style="background-color: #eee" class="sticky-top">
+                <ul class="nav flex-column nav-pills menu-sidebar" id="navbar" role="tablist">
+                    <li class="nav-item">
+                        <!--  Adds Home tab at the top which will serve as the base tab -->
+                        <a class="nav-link active" id="home-tab" data-toggle="tab" href="#home" role="tab"
+                           aria-controls="home" aria-selected="true">Using this Handbook</a>
+                    </li>
+                    {% for item in items_ordered %}
+                    <li class="nav-item">
+                        <a class="nav-link" id="{{ item.shorthand }}-tab" data-toggle="tab" href="#{{item.shorthand}}"
+                           role="tab" aria-controls="#{{item.shorthand}}" aria-selected="false">{{ item.title }}</a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
 
-  <!--  Define variable which sorts order of _comunities .md files -->
-  {% assign items_ordered = site.handbook | sort: "order" %}
+        <div class="col-md-8 col-lg-9">
+            <div class="tab-content">
+                <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">
+                    <p>
+                        The CSC Handbook is intended to act as an encyclopedia for all activities inside CSC. If you
+                        work in CSC, if you're new to the CSC Team, if you're a CSC collaborator, or if you're
+                        interested in joining CSC then the information you seek should be in here somewhere.
+                    </p>
+                </div>
 
-  <div class="col-md-4 col-lg-3 pb-3">
-    <!-- Handbook Scrollspy -->
-    <div id="scrollspy1" style="background-color: #eee" class="sticky-top">
-
-      <ul class="nav flex-column nav-pills menu-sidebar" id="handbookNav">
-      <h4 class="text-center pt-2">Handbook Contents</h4>
-          {% for item in items_ordered | sort: "order" %}
-              <li class="nav-item">
-                <a class="nav-link" href="#handbook-entry-{{item.order}}">{{ item.title }}</a>
-              </li>
-          {% endfor %}
-      </ul>
+                {% for item in items_ordered %}
+                <div class="tab-pane fade" id="{{item.shorthand}}" role="tabpanel"
+                     aria-labelledby="{{item.shorthand}}-tab">
+                    <h3>{{ item.title }}</h3>
+                    <p>{{ item.content }}</p>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
     </div>
-    <!-- Handbook Scrollspy -->
-  </div>
-
-  {% assign item_order = site.handbook | sort: "order" %}
-
-  <div class="col-md-8 col-lg-9">
-    <!-- Handbook Text (spied element) -->
-    <div
-      data-mdb-spy="scroll"
-      data-mdb-target="#scrollspy1"
-      data-mdb-offset="0"
-      class="scrollspy-example"
-    >
-        {% for item in items_ordered %}
-        <h3 id="handbook-entry-{{item.order}}">{{ item.title }}</h3>
-        {% if item.image %}
-            <p>{{ item.image }}</p>
-        {% endif %}
-        <p>{{ item.content }}</p>
-        {% endfor %}
-    </div>
-    <!-- Handbook Text (spied element) -->
-  </div>
-
+    <!--  JS scripts which enable deep linking i.e., guides.html#<reference to the specific tab> -->
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+            integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+            crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
+            integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
+            crossorigin="anonymous"></script>
+    <script src="assets/js/deeplinking.js"></script>
 </div>
-<!-- End Handbook -->

--- a/_includes/handbook.html
+++ b/_includes/handbook.html
@@ -5,13 +5,14 @@
   /*height: 200px;*/
   overflow: auto;
 }
+
 </style>
 
 <div class="container-fluid">
     <div class="row">
         <!--  Gets array of _handbook/ files and sorts them by descending "order" number -->
         {% assign items_ordered = site.handbook | sort: "order", "last" %}
-        <p> {{ items_shorthands }}</p>
+
         <div class="col-md-4 col-lg-3 pb-3">
             <div id="scrollspy1" style="background-color: #eee" class="sticky-top">
                 <ul class="nav flex-column nav-pills menu-sidebar" id="navbar" role="tablist">

--- a/assets/js/deeplinking.js
+++ b/assets/js/deeplinking.js
@@ -1,9 +1,10 @@
+
 $(document).ready(() => {
   let url = location.href.replace(/\/$/, "");
 
   if (location.hash) {
     const hash = url.split("#");
-    $('#guides-navbar a[href="#'+hash[1]+'"]').tab("show");
+    $('#navbar a[href="#'+hash[1]+'"]').tab("show");
     url = location.href.replace(/\/#/, "#");
     history.replaceState(null, null, url);
     setTimeout(() => {

--- a/assets/js/deeplinking.js
+++ b/assets/js/deeplinking.js
@@ -1,0 +1,25 @@
+$(document).ready(() => {
+  let url = location.href.replace(/\/$/, "");
+
+  if (location.hash) {
+    const hash = url.split("#");
+    $('#guides-navbar a[href="#'+hash[1]+'"]').tab("show");
+    url = location.href.replace(/\/#/, "#");
+    history.replaceState(null, null, url);
+    setTimeout(() => {
+      $(window).scrollTop(0);
+    }, 400);
+  }
+
+  $('a[data-toggle="tab"]').on("click", function() {
+    let newUrl;
+    const hash = $(this).attr("href");
+    if(hash == "#home") {
+      newUrl = url.split("#")[0];
+    } else {
+      newUrl = url.split("#")[0] + hash;
+    }
+    newUrl += "/";
+    history.replaceState(null, null, newUrl);
+  });
+});


### PR DESCRIPTION
This PR resolves #176 and:

- Fixes an issue with the Guides page wherein users were unable directly link to individual sections in the navigation bar i.e., deep linking (see [here](https://webdesign.tutsplus.com/tutorials/how-to-add-deep-linking-to-the-bootstrap-4-tabs-component--cms-31180) for more information)
- Updates the Handbook page to match the Guides page post-fix
- Renames the **NHS Admin** section in the Handbook page to **NHS Staff Admin** for clarity, and adds two sections related to annual leave and remote working