### PR TITLE
Corrects formatting issues found in the racial bias workshop write up

### DIFF
--- a/blogs/workshops/_posts/2021-06-02-10x-RacialBias.md
+++ b/blogs/workshops/_posts/2021-06-02-10x-RacialBias.md
@@ -37,7 +37,6 @@ initiative in January 2021 but no laws currently exist to ban such software. Som
 has also been recorded in the UK but has met with more 
 <a href="https://www.ft.com/content/79223f6e-a772-4e74-b256-88641a416f92">hesitancy from government</a> officials.
 
-
 #### Health Insurance AI (USA)
 
 We discussed the paper by <a href="https://www.science.org/doi/abs/10.1126/science.aax2342">Obermayer et al (2019)</a> 
@@ -49,12 +48,12 @@ the information on race was deliberately excluded, but the total healthcare cost
 surrogate measure for healthcare needs and number of chronic conditions. The algorithm designers and developers failed 
 to account for differences in the way healthcare systems are accessed in USA and how that ties in with race, 
 socioeconomic background and location. The system therefore failed to account for systemic discrimination embedded in 
-society and produced an algorithm that furthered it
+society and produced an algorithm that exacerbated it.
 
 #### Chest X-Ray
 We discussed a case of a chest x-ray algorithm which was trained on publicly available datasets which contained 
 significantly more male patients than female patients which resulted in an algorithm less accurate for 
-<a href="https://www.pnas.org/content/117/23/12592">female patients than male patients</a>.</ul>
+<a href="https://www.pnas.org/content/117/23/12592">female patients than male patients</a>.
 
 #### Dermatology
 We discussed the ongoing issue in dermatology of under-representation of darker-skinned individuals in training, 
@@ -72,63 +71,63 @@ bias by ensuring sufficient data on darker-skinned individuals is included in th
 Then we discussed the origins of health injustice across the globe by focussing on the following four points:
 
 #### Global health injustice
-The 10/90 gap is a term commonly used in global discussions on health research to highlight that less than 10% of total
+- The 10/90 gap is a term commonly used in global discussions on health research to highlight that less than 10% of total
 worldwide health research funding is devoted to illnesses that affect 90% of the global population, particularly as the 
 majority of those illnesses disproportionately affect poorer populations or populations in poorer countries. The amount
 of focus, funding and data is therefore likely to serve populations already well served – this should be kept in mind 
 when choosing which problems should be solved first.
 
 #### Racial Injustice
-The 10/90 gap can be found in research which focuses on genetic disorders which are related to race. The example we 
+- The 10/90 gap can be found in research which focuses on genetic disorders which are related to race. The example we 
 discussed is sickle cell anaemia, a genetic disorder that affects predominantly Black patients, and cystic fibrosis,
 a genetic disorder that affect predominantly White patients. Cystic fibrosis research is
 <a href="https://jamanetwork.com/journals/jamanetworkopen/fullarticle/2763606">substantially better funded that sickle 
-cell anaemia research</a>, resulting in more research articles published and more treatments approved by the FDA.</ul>
+cell anaemia research</a>, resulting in more research articles published and more treatments approved by the FDA.
 
-Maternal death and negative outcomes associated with pregnancy and childbirth are significantly higher in people of 
+- Maternal death and negative outcomes associated with pregnancy and childbirth are significantly higher in people of 
 colour than in White people. This trend can be observed both in the UK and the USA and has worsened over time. The root
 cause of this disparity is not clear and so the remedy for this discrepancy is not straightforward. Speculatively and 
 anecdotally, the reason for worse outcomes can be tied to structural racism which affects people of colour in their 
 everyday lives in the way they access healthcare, the way they are treated within healthcare services, the way they 
-interact with community support and so on.</ul>
+interact with community support and so on.
 
 #### Gender Injustice
-Menstrual health affects approximately half of the population for a significant portion of their lifetime but is 
+- Menstrual health affects approximately half of the population for a significant portion of their lifetime but is 
 largely stigmatised as a topic of conversation and underrepresented as a topic for research. A disease-specific example 
 is endometriosis which is a common and painful condition affecting an estimated 10% of menstruating population worldwide
 but which is chronically under-diagnosed, largely unstudied and for most individuals remains untreated throughout their 
-lives even though the pain associated with the condition can be debilitating.</ul>
+lives even though the pain associated with the condition can be debilitating.
 
-Healthcare of transgender people is still not a focus in global research, despite hormone replacement therapies being 
+- Healthcare of transgender people is still not a focus in global research, despite hormone replacement therapies being 
 associated with higher incidence of some gender-specific cancers (such as breast and prostate cancers) and despite an 
 increase in HIV/AIDS prevalence in transgender sex workers. Transgender people are frequently missed from screening 
-services and face systemic discrimination when seeking healthcare worldwide.</ul>
+services and face systemic discrimination when seeking healthcare worldwide.
 
 #### Diversity of the scientific workforce
-Scientific workforce worldwide is not diverse and lacks in gender, racial and socioeconomic representation. It is 
+- Scientific workforce worldwide is not diverse and lacks in gender, racial and socioeconomic representation. It is 
 still predominantly white, male and has origins associated with higher socioeconomic status. Non-wealthy and non-white 
 individuals are still very weakly represented in academia as well as boards in tech industry and healthcare boards, 
 including in the NHS. The obvious problem this creates is that many marginalised groups do not have sufficient advocacy 
 at decision-making levels and are thus insufficiently served by the community and sometimes entirely omitted from the 
-conversation, intentionally or unintentionally. </ul>
+conversation, intentionally or unintentionally.
 
 ### The Solutions
 
 The strategies most commonly advised in literature as methods of avoiding bias in data, whether gender, socioeconomic 
 or racial are the following:
 
-#### Diversity in data:
+##### Diversity in data:
 The data collected for algorithm training purposes needs to be representative and include all potential patients, 
 ideally in equal measure (i.e. 'the real world data').
 
 
-#### Diversity in validation:
+##### Diversity in validation:
 
 The data collected for algorithm testing must include sufficiently representative sample of patient data, including 
 any minority or marginalised group that may be subjected to the algorithm’s decision-making. The algorithm must perform
 equally well across all relevant patient groups.
 
-**Diversity in people:**
+##### Diversity in people:
 
 It is crucial that the team designing, training and developing algorithms is diverse in gender, socioeconomic, 
 religious and/or ethnic background to ensure advocacy from design until deployment and beyond for as many patient 


### PR DESCRIPTION
removes the <ul>s and uses markdown for bullet points removes stray markdown and replaces it with appropriate markdown at 'diversity in people' section

content not amended