### PR TITLE
Adds guide on how to contribute to website development

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ _Please flag any issues with these instructions as I have mostly written from me
    - The master branch is called `gh-pages`.
 4. `bundle install`
    - This builds the website locally on your machine.
+   - For Apple Silicon (ARM) e.g., M1 Mac users, you may need to run `arch -arch x86_64 bundle install` if the above does not work.
 5. `bundle exec jekyll serve --livereload`
    - This runs the website locally on your machine.
+   - For Apple Silicon (ARM) e.g., M1 Mac users, you may need to run `arch -arch x86_64 bundle exec jekyll serve` if the above does not work.
    - The `--livereload` option enables you to see changes to your code automatically in your browser, without rebuilding the code.
    - NB: the `--livereload` option does not work with changes to the `config.yml` file. In this case, you will need to re-run `bundle exec jekyll serve --livereload`.
 6. View in your browser with the URL: [http://localhost:4000](http://localhost:4000/)

--- a/_guides/how-to-contribute.md
+++ b/_guides/how-to-contribute.md
@@ -8,7 +8,7 @@ shorthand: Contributing
 If you would like to contribute to the development of this website, we suggest you:
 
 1. If there isn't already an [existing Issue](https://github.com/GSTT-CSC/gstt-csc.github.io) that covers the bug fix and/or feature(s) you want to fix and/or add, [create a new Issue](https://github.com/GSTT-CSC/gstt-csc.github.io/issues/new/choose).
-2. Fork or clone the repository (see the GitHub documentation [here](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) for more information on how to do so).
+2. Go to the GitHub repository [here](https://github.com/GSTT-CSC/gstt-csc.github.io) and fork or clone the repository (see the GitHub documentation [here](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) for more information on how to do so).
 3. Checkout the main i.e., ``gh-pages`` branch first by running ``git checkout -b gh-pages``.
 4. Create your Bugfix or Feature Branch off of ``gh-pages`` (``git checkout -b bug/BugFix`` or ``git checkout -b feature/AmazingFeature``).
 5. Commit your changes (``git commit -m 'Fixes a SmallBug'`` or ``git commit -m 'Adds some AmazingFeature'``).

--- a/_guides/how-to-contribute.md
+++ b/_guides/how-to-contribute.md
@@ -1,0 +1,25 @@
+---
+title: How to contribute
+shorthand: Contributing
+---
+
+##### Website Development
+
+If you would like to contribute to the development of this website, we suggest you:
+
+1. If there isn't already an [existing Issue](https://github.com/GSTT-CSC/gstt-csc.github.io) that covers the bug fix and/or feature(s) you want to fix and/or add, [create a new Issue](https://github.com/GSTT-CSC/gstt-csc.github.io/issues/new/choose)
+2. Fork or clone the repository (see the GitHub documentation [here](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) for more information on how to do so)
+3. Since all code changes should be staged on the ``develop`` branch before releases, you will need to checkout this branch first (``git checkout -b develop``)
+4. Create your Bugfix or Feature Branch off of `develop` (``git checkout -b bug/BugFix`` or ``git checkout -b feature/AmazingFeature``)
+5. Commit your changes (``git commit -m 'Fixes a SmallBug'`` or ``git commit -m 'Adds some AmazingFeature'``)
+   - For commit messages, we recommend this [commit message style](https://cbea.ms/git-commit/) (see [here](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) for simplified summary)
+6. Push to the remote (``git push bug/BugFix`` or ``git push origin feature/AmazingFeature``)
+7. Open a [Pull Request (PR)](https://github.com/GSTT-CSC/gstt-csc.github.io/compare) and specify that you want to merge your branch into the ``develop`` branch
+8. A CSC team member will review your PR and, if approved, merge it into the ``develop`` branch.
+
+Code changes in the ``develop`` branch will be periodically merged into the ``gh-pages`` branch and the changes will be automatically reflected in the live website.
+
+
+###### Reviewing your changes during development
+
+You can view your changes during development with a locally-hosted version of the website on your machine by following the Installation instructions in the GitHub repository's README [here](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)).

--- a/_guides/how-to-contribute.md
+++ b/_guides/how-to-contribute.md
@@ -7,18 +7,17 @@ shorthand: Contributing
 
 If you would like to contribute to the development of this website, we suggest you:
 
-1. If there isn't already an [existing Issue](https://github.com/GSTT-CSC/gstt-csc.github.io) that covers the bug fix and/or feature(s) you want to fix and/or add, [create a new Issue](https://github.com/GSTT-CSC/gstt-csc.github.io/issues/new/choose)
-2. Fork or clone the repository (see the GitHub documentation [here](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) for more information on how to do so)
-3. Since all code changes should be staged on the ``develop`` branch before releases, you will need to checkout this branch first (``git checkout -b develop``)
-4. Create your Bugfix or Feature Branch off of `develop` (``git checkout -b bug/BugFix`` or ``git checkout -b feature/AmazingFeature``)
-5. Commit your changes (``git commit -m 'Fixes a SmallBug'`` or ``git commit -m 'Adds some AmazingFeature'``)
-   - For commit messages, we recommend this [commit message style](https://cbea.ms/git-commit/) (see [here](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) for simplified summary)
-6. Push to the remote (``git push bug/BugFix`` or ``git push origin feature/AmazingFeature``)
-7. Open a [Pull Request (PR)](https://github.com/GSTT-CSC/gstt-csc.github.io/compare) and specify that you want to merge your branch into the ``develop`` branch
-8. A CSC team member will review your PR and, if approved, merge it into the ``develop`` branch.
+1. If there isn't already an [existing Issue](https://github.com/GSTT-CSC/gstt-csc.github.io) that covers the bug fix and/or feature(s) you want to fix and/or add, [create a new Issue](https://github.com/GSTT-CSC/gstt-csc.github.io/issues/new/choose).
+2. Fork or clone the repository (see the GitHub documentation [here](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) for more information on how to do so).
+3. Checkout the main i.e., ``gh-pages`` branch first by running ``git checkout -b gh-pages``.
+4. Create your Bugfix or Feature Branch off of ``gh-pages`` (``git checkout -b bug/BugFix`` or ``git checkout -b feature/AmazingFeature``).
+5. Commit your changes (``git commit -m 'Fixes a SmallBug'`` or ``git commit -m 'Adds some AmazingFeature'``).
+   - For commit messages, we recommend this [commit message style](https://cbea.ms/git-commit/) (see [here](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) for simplified summary).
+6. Push to the remote (``git push bug/BugFix`` or ``git push origin feature/AmazingFeature``).
+7. Open a [Pull Request (PR)](https://github.com/GSTT-CSC/gstt-csc.github.io/compare) and specify that you want to merge your branch into the ``gh-pages`` branch.
+8. A CSC team member will review your PR and, if approved, merge it into the ``gh-pages`` branch and the changes will be automatically updated in the live website.
 
-Code changes in the ``develop`` branch will be periodically merged into the ``gh-pages`` branch and the changes will be automatically reflected in the live website.
-
+⚠️ If, at any point, you find something unexpected happens or require further support, [please reach out to us](mailto:CSCTeam@gstt.nhs.uk). 
 
 ###### Reviewing your changes during development
 


### PR DESCRIPTION
This PR resolves #175.

**Notes for reviewer feedback** 

- The [original guide](https://github.com/GSTT-CSC/gstt-csc-old/blob/6415913c97f175e457e1ce999c301f37916c8ad3/howto.md) advised contributors to raise PRs to merge into the `main` branch i.e., now `gh-pages`. I've changed this to `develop` since I noticed there is one in the repo, plus it seems to be the norm for our contributing guidelines in other repos.
- I've removed the explicit instructions on, for example, cloning the repository, local installation, etc. and linked to the official or original source of documentation to avoid (1) duplication of work and (2) content consistency.