### PR TITLE
Adds embedded Excel workbook as XNAT calculator

### DIFF
--- a/_platforms/xnat.md
+++ b/_platforms/xnat.md
@@ -32,3 +32,21 @@ For a wealth of information, including our SOPs, anonymisation scripts, data ret
 If you would like to us to retrieve data for your project and perform the relevant anonymisation process, please fill in the [data
 request form](../../assets/docs/CSC-XNATdataRequestForm-V1.docx) and <a href="mailto:CSCTeam@gstt.nhs.uk">email</a> us with your data request. Please attach appropriate ethics approvals to the
 email.
+
+#### Estimated quote calculator for new projects
+For an initial estimated quote for new projects, please use the below calculator, specifically editing the first two columns on the left-hand side, to confirm:
+
+- The project name
+- The project lead
+- The requestor organisation
+- Whether a National Data Opt-Out check is required for the patient cohort
+- Target completion date i.e., for all requested tasks to be completed
+- Number of studies required
+- Tasks and associated modalities required
+
+Once finished, please:
+
+- Include the Total Estimated Project Cost in your new project request
+- Retain a screenshot as we will request this be sent to us via email after we've reviewed your request
+
+<iframe width="700" height="450" frameborder="0" style="border: 5px solid black;" scrolling="no" src="https://emckclac-my.sharepoint.com/:x:/g/personal/k2252499_kcl_ac_uk/EXS5NZSBoqtLutkCXBP3QlMBXcl0s8H6QLJY6_PDYBV7JQ?e=aDgc9i&action=embedview&wdAllowInteractivity=False&AllowTyping=True&ActiveCell='Invoice'!B1&Item='Invoice'!A1%3AC20&wdHideGridlines=True&wdInConfigurator=True&wdInConfigurator=True"></iframe>


### PR DESCRIPTION
This PR solves #173 by adding an embedded Excel workbook to enable users to calculate an initial estimated quote for new XNAT projects.

**Caveats & considerations:**
- The workbook has been protected to hide underlying sheets with rates because referencing defined ranges in external workbooks doesn't seem to work online and/or via KCL Microsoft 365
- The specific Invoice sheet has been protected to (1) disable editing of the third column to the right-hand side i.e., calculated costs and (2) hide formulas
- The embedded link used needs to grant anyone access without downloads being disabled in order to allow users to be able to view the workbook without a Microsoft 365 login and select from dropdown lists, respectively
  - The workbook needs to be saved in an individual account as MT-CSC does not allow links to be created with level of access
  - The download button has been disabled but users can still view (and then download) the workbook in separate window