### PR TITLE
216 Add Stale Public Repos

### DIFF
--- a/.github/workflows/update_stale_repos.yml
+++ b/.github/workflows/update_stale_repos.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         head -9 _handbook/csc_github.md > ./temp.md
         rm _handbook/csc_github.md
-        cat ./temp.md ./stale_repos.md > _handbook/csc_github.md
+        cat ./temp.md <(echo) ./stale_repos.md > _handbook/csc_github.md
     - name: Commit and push
       run: |
         git config user.name 'github-actions[bot]'

--- a/.github/workflows/update_stale_repos.yml
+++ b/.github/workflows/update_stale_repos.yml
@@ -1,0 +1,33 @@
+name: Update Stale Repos
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '5 0 * * *'
+
+jobs:
+  build:
+    name: Update Stale Repos
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Run stale_repos tool
+      uses: github/stale-repos@v1
+      env:
+        GH_TOKEN: ${{ secrets.PUB_GH_TOKEN }}
+        ORGANIZATION: 'GSTT-CSC'
+        INACTIVE_DAYS: 180
+    - name: get csc_github.md and append updated stale repos
+      run: |
+        head -9 _handbook/csc_github.md > ./temp.md
+        rm _handbook/csc_github.md
+        cat ./temp.md ./stale_repos.md > _handbook/csc_github.md
+    - name: Commit and push
+      run: |
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+        git add _handbook/csc_github.md
+        git commit -m "Update stale repos" || echo "No changes"
+        git push

--- a/.github/workflows/update_stale_repos.yml
+++ b/.github/workflows/update_stale_repos.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Run stale_repos tool
       uses: github/stale-repos@v1
       env:
-        GH_TOKEN: ${{ secrets.PUB_GH_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ORGANIZATION: 'GSTT-CSC'
         INACTIVE_DAYS: 180
     - name: get csc_github.md and append updated stale repos

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 642 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 466 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 643 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 467 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 651 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 475 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 652 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 476 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -6,7 +6,7 @@ shorthand: CSC-GitHub
 order: 8
 ---
 
-The CSC GitHub can be found here – <a href="https://github.com/GSTT-CSC/">CSC Github</a>.# Inactive Repositories
+The CSC GitHub can be found here – <a href="https://github.com/GSTT-CSC/">CSC Github</a>.
 
 # Inactive Repositories
 

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 640 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 464 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 641 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 465 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 647 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 471 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 648 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 472 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 645 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 469 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 646 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 470 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 638 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 462 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 639 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 463 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 655 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 479 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 656 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 480 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 646 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 470 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 647 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 471 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 637 | 2021-11-21 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 638 | 2021-11-21 |
 | https://github.com/GSTT-CSC/gstt-csc-old | 462 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 648 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 472 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 649 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 473 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 641 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 465 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 642 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 466 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 653 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 477 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 654 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 478 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 639 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 463 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 640 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 464 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 652 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 476 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 653 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 477 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 650 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 474 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 651 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 475 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 644 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 468 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 645 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 469 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 656 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 480 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 657 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 481 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -8,6 +8,8 @@ order: 8
 
 The CSC GitHub can be found here – <a href="https://github.com/GSTT-CSC/">CSC Github</a>.# Inactive Repositories
 
+# Inactive Repositories
+
 The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 654 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 478 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 655 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 479 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -6,4 +6,11 @@ shorthand: CSC-GitHub
 order: 8
 ---
 
-The CSC GitHub can be found here – <a href="https://github.com/GSTT-CSC/">CSC Github</a>.
+The CSC GitHub can be found here – <a href="https://github.com/GSTT-CSC/">CSC Github</a>.# Inactive Repositories
+
+The following repos have not had a push event for more than 180 days:
+
+| Repository URL | Days Inactive | Last Push Date |
+| --- | --- | ---: |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 637 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 462 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 643 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 467 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 644 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 468 | 2022-05-16 |

--- a/_handbook/csc_github.md
+++ b/_handbook/csc_github.md
@@ -14,5 +14,5 @@ The following repos have not had a push event for more than 180 days:
 
 | Repository URL | Days Inactive | Last Push Date |
 | --- | --- | ---: |
-| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 649 | 2021-11-21 |
-| https://github.com/GSTT-CSC/gstt-csc-old | 473 | 2022-05-16 |
+| https://github.com/GSTT-CSC/Flask_BarrettsNLP | 650 | 2021-11-21 |
+| https://github.com/GSTT-CSC/gstt-csc-old | 474 | 2022-05-16 |


### PR DESCRIPTION
This adds a table of stale public repos within the CSC organisation on github to https://gstt-csc.github.io/handbook.html#CSC-GitHub/

The table is updated automatically via a github actions workflow every day at 00:05 and can also be manually run.

For this to be possible the actions bot might need to be given write permissions if this isn't already the case.

Currently the number of days without a commit for a repo to be counted as stale is 180 but this can be changed.