### PR TITLE
Updates Onboarding page

### DIFF
--- a/_guides/room_booking.md
+++ b/_guides/room_booking.md
@@ -19,7 +19,10 @@ To book a room, you will need to provide the required:
 
 For **Tabard House**, the preferred room is the **Library** on the ground floor* and booking requests should be sent via email to the Medical Physics department's Assistant Service Manager.
 
-For **York Road**, the preferred room is the **Glass Meeting Pod** on the 10th Floor and booking requests should be sent via email to the Executive Assistant (EA) to the Deputy Chief Executive's Office.
+For **York Road**, you can either book:
+
+- The **Glass Meeting Pod** on the 10th Floor via a request emailed to the Executive Assistant (EA) to the Deputy Chief Executive's Office.
+- Other rooms in the building via the [MICAD room booking website](https://gstt.nhs.micadipr.net/pages/roomMonitoringClients/rmSignIN.asp?return=%2Fpages%2FroomMonitoringClients%2FrmRoomSearchForClients%2Easp%3F), which **must be accessed via the Trust VPN i.e., Citrix, if not on-site**.
 
 \* _You will need an access code to enter this floor in Tabard House. If this has not already been provided, please email the [CSC Team](mailto:CSCTeam@gstt.nhs.uk)._
 

--- a/_guides/room_booking.md
+++ b/_guides/room_booking.md
@@ -22,7 +22,7 @@ For **Tabard House**, the preferred room is the **Library** on the ground floor*
 For **York Road**, you can either book:
 
 - The **Glass Meeting Pod** on the 10th Floor via a request emailed to the Executive Assistant (EA) to the Deputy Chief Executive's Office.
-- Other rooms in the building via the [MICAD room booking website](https://gstt.nhs.micadipr.net/pages/roomMonitoringClients/rmSignIN.asp?return=%2Fpages%2FroomMonitoringClients%2FrmRoomSearchForClients%2Easp%3F), which **must be accessed via the Trust VPN i.e., Citrix, if not on-site**.
+- Other rooms in the building, as well as other sites such as Minerva House and Great Dover Street, via the [MICAD room booking website](https://gstt.nhs.micadipr.net/pages/roomMonitoringClients/rmSignIN.asp?return=%2Fpages%2FroomMonitoringClients%2FrmRoomSearchForClients%2Easp%3F), which **must be accessed via the Trust VPN i.e., Citrix, if not on-site**.
 
 \* _You will need an access code to enter this floor in Tabard House. If this has not already been provided, please email the [CSC Team](mailto:CSCTeam@gstt.nhs.uk)._
 

--- a/_handbook/onboarding.md
+++ b/_handbook/onboarding.md
@@ -6,96 +6,106 @@ shorthand: Onboarding
 order: 4
 ---
 
-**Access to Becket House**
-   - Email Karon Galvin for access
-   - Fill out risk form and complete training
-   - Collect card at reception on ground-floor
-   - Get a local tour of Becket House 5th and 9th floor from a CSC Team Member
-
-**CSC Desk Area**
-   - The CSC team resides on level 5 of Becket House
-   - Enter the doors titled 'Big Ben side'
-
-
-**10th-floor York Road Booking Instructions**
-
-The CSC team has desk availability at the 10th floor of the Education Center in York Road. In order to get there you 
-will need to:
-Access is granted from the security desk at York Road after they receive an email from line manager. After this is done,
-you can just swipe your card at the entrance.
-
-
-**Booking meeting rooms in GSTT (not KCL)** 
-
-There is a central room booking service allowing GSTT staff to book a variety of
-meeting rooms (without charge) across our sites including Minerva and Great Dover
-Street.
-
-Go to [Room Booking](https://gstt.nhs.micadipr.net/pages/roomMonitoringClients/rmSignIN.asp?return=%2Fpages%2FroomMonitoringClients%2FrmRoomSearchForClients%2Easp%3F) from the GSTT network (using Citrix if not onsite)
-
-
-Simply register an account and complete your request (date/time/room size and function) and a selection of options come 
-up which you can proceed to book online.
-
-**Electronic Staff Record**
-
-In order to check payslips, p60, pension contributions etc. you need to get access to your Electronic Staff Record.
-   - Browse https://my.esr.nhs.uk/dashboard/web/esrweb
-   - Go to login to ESR
-   - Click Unlock Account if is your first time
-   - Fill in details and wait for an email with instructions. It will usually be your username and a link to set up your password
-
-**Citrix Access**
-
-Citrix allows you to access GSTT network when you are at home. In order to get access you have to:  
-   - Call St Thomas' at 020 7188 7188 and ask to be redirected to IT
-   - Once connected, ask about the steps to get access to Citrix
-   - You will receive an email with detailed instructions
-
-**Get Access to GitHub**
-
-The CSC use GitHub for code storage and version control for all applications in-house, and additionally, to host the 
-Quality Management System. Each new staff member must create a GitHub account and get the Head of CSC to add them to 
-GSTT-CSC organisation on GitHub. 
-
-The joiner should search for issues with the "Good First Issue" tag to contribute to current projects and to become 
-familiar with CSC software development process.  
-
 **Arrange 1-2-1's with all CSC Staff**
 
-New starters will be expected to arrange 30 min meetings with each staff member of the CSC, on Teams or in-person, for 
+New starters will be expected to arrange 30-minute meetings with each staff member of the CSC, on Teams or in-person, for 
 introductions as early familiarity with the team encourages a supportive working culture. The meetings should discuss:
 
-- Career to date ( new starter and current staff member)
+- Career to date (new starter and current staff member)
 - Length of new-starters time with the CSC
 
-(For trainees/elective staff) 
-- experiences you wish to gain with the CSC.
-- competencies that could be completed
-
-**Create "Team-Member" Website Profile**
-All new staff and trainees must create a new page and profile on the website, along with a picture (250x250px) and socials links. 
+For trainees and elective staff, the meetings should also discuss:  
+- Experiences you wish to gain with the CSC
+- Competencies that could be completed
 
 **Meeting invites**
 
-Organise with the Head of CSC or CSC staff to be added to the following meetings and groups:
-- Added to MT_CSC Microsoft Teams to have access to CSC chat, files, calendar and emails
-- The 10X meeting series (fortnightly wednesday afternoon in-person sessions)
-- Bi-weekly stand-ups (Tues/Thurs 09:30 AM)
-- Up and coming QMS audits (internal and external)
+New starts should organise with the Head of CSC or CSC staff to be added to the following meetings, groups, and Microsoft Teams:
+
+- KCL Microsoft Teams i.e., to access main CSC chat, MT_CSC OneDrive, KCL calendar, etc.
+- GSTT Microsoft Teams i.e., to access secondary CSC chat, GSTT-shareable only files, GSTT calendar, etc.
+- 10X Workshops meeting series (fortnightly in-person sessions 3 - 5:30PM i.e., every other Wednesday)
+- Bi-weekly stand-ups (9:30 - 10AM on Tuesdays and Thursdays)
+- Quality Management System (QMS) audits (internal and external)
 - Interesting project meetings
-- Conferences 
+- Conferences
+
+**CSC Desk Area**
+
+The CSC team mainly resides on the 10th Floor in the [Education Centre](https://maps.app.goo.gl/J5BUnrPw1eHsNDdq8) (also referred to as **York Road**), but can also be granted access to:
+
+- **Tabard House** ([near Guy's Hospital](https://maps.app.goo.gl/jDNeBb3Q21Bd7eUL8))
+- The 5th ("Big Ben" side) and 9th floor (meeting rooms) in [**Becket House**](https://maps.app.goo.gl/g3Rc6bPowryfpby16) 
+  - For access, please email the Operations Assistant for the Biomedical Engineering department for the necessary forms, training, KCL card issuance, and guidance.
+
+Access to these sites should be requested and approved by your line manager, and implemented so you can simply swipe your card at the entrance. 
+
+**Access to GSTT-specific websites**
+
+New starters should ensure they register and have access to:
+
+- [MICAD room booking system](https://gstt.nhs.micadipr.net/pages/roomMonitoringClients/rmSignIN.asp?return=%2Fpages%2FroomMonitoringClients%2FrmRoomSearchForClients%2Easp%3F)* i.e., to book meeting rooms across GSTT sites.
+- [Electronic Staff Record (EST)](https://my.esr.nhs.uk/dashboard/web/esrweb) i.e., to access payslips, P60 forms, pension contributions, etc.
+  - Click on "Unlock Account" to register for the first time.
+- [HR Portal](https://fids.gstt.nhs.uk/adfs/ls/)** i.e., to raise and manage HR requests/transactions, access HR policies, etc.
+- [IT Service Centre](https://gstt.service-now.com/ess/?id=my_requests)** i.e., to raise and manage IT requests/incidents, access the IT system catalogue, etc.
+
+\* _Accessible only via the Trust VPN i.e., either on-site or whilst logged into Citrix (see below for how to set up this remote desktop and application access)_.
+
+\** _The usernames used to logged into these websites are either your GSTT email address or GSTT username, and the password used will be the password you use to login to your email and desktop on-site_.
+
+**Access to remote desktop and applications i.e., via the Trust VPN on Citrix**
+
+New starters should ensure they set up and can access their remote Trust desktop and applications.
+
+1. Set up SafeNet Mobile Pass for One Time Passcodes (OTP) to use in conjunction with your GSTT account password
+   - Submit the "Remote access request" form on the [IT Service Centre website](https://gstt.service-now.com/ess/?id=my_requests) and request that the setup guide be sent to you by IT once the ticket has been completed.
+   - Download the SafeNet Mobile Pass application on an easily accessible device e.g., phone or tablet.
+2. Set up Citrix either by:
+   - Installing the Citrix Workspace app from [here](https://www.citrix.com/products/receiver.html) and connecting to GSTT's server i.e., https://connect.gstt.nhs.uk **(recommended)**
+   - Bookmarking the Citrix login website [here](https://connect.gstt.nhs.uk/vpn/index.html)
+      - This will require you to download the images of your remote desktop and/or application(s) to open them and you will need to manually delete these files from your Downloads folder. 
+   
+After completing the above steps, you should be able to access your GSTT applications remotely by logging onto Citrix with your GSTT username and password, and OTO generated on the SafeNet Mobile Pass application. If you require access to your GSTT desktop i.e., a single remote desktop window with multiple applications contained therein, and this has not been automatically enabled in your Citrix, please contact IT. 
+
+**Access to GSTT data platforms**
+
+Depending on the projects you will be involved in, you may also need to request access for and familiarise yourselves with the following data platforms to collaborate with the rest of the project team. 
+
+- **The Clinical Analytics team's enterprise data warehouse (EDW) (also referred to as _Health Catalyst_ or _HC_)**
+  - Email the Head of the Clinical Analytics team to request for access to this SQL server data warehouse and provide:
+    - The date of your most recent Information Governance (IG) training
+    - Details on what type of data you require and why
+    - Any IG and project approvals relevant to your project
+- **CRIS***
+  - Email the Head of CSC for request for access to the application and up-to-date guidance on who to directly contact, if applicable.
+- **XNAT**
+  - Email the CSC team's XNAT administrators to request for access to this [imaging informatics platform](https://xnat.org/) and training.
+
+\* _To be updated post-Epic go live in October 2023_.
+
+In terms of technical skills required to interact with these platform, there is often a Graphical User Interface (GUI) available but **some familiarity with Python and SQL is recommended**.
+
+**Access to CSC GitHub**
+
+The CSC team uses GitHub for code storage and version control for all applications built in-house, as well as the 
+team's QMS. Each new staff member must create a GitHub account and get the Head of CSC to add them to the [GSTT-CSC GitHub organisation](https://github.com/GSTT-CSC). 
+
+The new starter should search for issues with the "Good First Issue" tag to contribute to current projects and to become 
+familiar with CSC software development process.
+
+**Create "Team-Member" Website Profile**
+
+All new staff and trainees must create a new page and profile on the ["Meet the Team" page](https://gstt-csc.github.io/team.html) on the website, along with a picture (250x250px) and any social media links e.g., GitHub, LinkedIn, etc. To do so, please refer to the README on the website's GitHub repository [here](https://github.com/GSTT-CSC/gstt-csc.github.io).
 
 **STP Trainee On-boarding Tasks**
 
-In addition to all the above, STP trainees must:
+In addition to all of the above, STP trainees must:
 
-- **Create blog posts** - outlining an interesting project completed or 10X, and an account of the experience of their duration with the CSC Team, with feedback. E.g.  
+- **Create a blog posts** outlining an interesting project completed or 10X, and an account of the experience of their duration with the CSC Team, with feedback. Examples of blog posts created by STPs include:  
   - [Bioinformatics Trainee](blogs/articles/2021/08/25/STP_blog_Igor.html)
   - [Clinical Engineering Trainee](/blogs/articles/2022/07/01/STP_blog_Isabella.html)
-- **Communicate *wanted* experience** - as opposed to *needed* experience, separating out the trainees interests from tasks required by the competencies/CSC workload.
+- **Communicate *wanted* experience** (as opposed to *needed* experience) to separate out the trainees' interests from tasks required by the competencies and/or CSC workload.
 - **Get assigned 1st and 2nd Supervisor**
 - **Organise weekly check-in sessions with supervisors**
-- **Confirm a schedule for completing projects, competencies, DOPS, ICE's**
-
-[**Get Involved!**](/getinvolved.html) - How to join the CSC Team at GSTT
+- **Confirm a schedule for completing projects, competencies, DOPS, ICE's, etc.**


### PR DESCRIPTION
This PR:

- Adds MICAD guidance to the Room Booking guide
- Reformats and updates the Onboarding page e.g., to add more details on Citrix setup and access to data platforms