### PR TITLE
Landing page text edit: even clearer wording on NHS recruitment

### DIFF
--- a/_pages/fellowship.md
+++ b/_pages/fellowship.md
@@ -4,11 +4,11 @@ title: Fellowship in Clinical Artifical Intelligence
 permalink: /fellowship.html
 description:
 ---
-The Fellowship in Clinical AI is a year-long programme which is integrated part-time alongside clinical work.
+The Fellowship in Clinical AI is a 12-month programme which is integrated part-time alongside clinical work.
 
-Our fellows are smart and energetic individuals who will lead the charge to revolutionise clinical workflows with AI.
-Fellows are recruited competitively from various clinical workforce groups across participating regions of the NHS, including medical and dental specialty trainees, nurses & midwives, AHPs, and pharmacy professionals.
-
+Fellows are recruited competitively from 7 participating regions across the NHS, drawn from a diverse clinical workforce including: medical and dental specialty trainees, nurses & midwives, allied health professionals, and pharmacy professionals.
+Our fellows are smart and energetic individuals who will be equipped to adopt clinical artificial intelligence tehcnology.
+Fellows gain experience deploying AI in clinical workflows in 12-month project placements, under expert supervision in multidisciplinary teams.
 
 This unique programme is featured in the [NHS Long Term Workforce Plan](https://www.england.nhs.uk/publication/nhs-long-term-workforce-plan/) as an exemplar of upskilling staff to maximise the transformational benefit of AI technologies in the NHS.
 
@@ -21,7 +21,7 @@ Clinical leaders with expertise in Artificial Intelligence are essential to the 
 To fully deliver the UK government's goal of being a [global AI superpower](https://assets.publishing.service.gov.uk/media/614db4d1e90e077a2cbdf3c4/National_AI_Strategy_-_PDF_version.pdf), the NHS must provide dedicated training for clinicians in cutting-edge skills required for clinical AI deployment.
 This fellowship is the first systematic route in the UK to acquire the relevant skills in clinical AI deployment. Fellows  gain expertise in clinical AI alongside their existing roles and implement state-of-the-art AI software in live hospital environments.
 
-Fellows are matched with an expert AI supervisor to gain experience in real-world applications of clinical AI. Fellows gain skills and knowledge relevant to the full life cycle of healthcare AI from a bespoke programme of teaching aligned with the Clinical AI Curriculum developed by the faculty.
+Fellows are matched with an expert AI supervisor and team to gain experience in real-world applications of clinical AI. Fellows gain skills and knowledge relevant to the full life cycle of healthcare AI from a bespoke programme of teaching aligned with the Clinical AI Curriculum developed by the faculty.
 As a lasting legacy of the fellowship, fellows become part of a uniquely networked community of interest within the healthcare AI community.
 
 >"I’m so proud of what you’re doing. I look forward to following your career paths because you’re going to light it up. You’re going to be the change agents for medicine, and we sure need it." <br/>Professor Eric Topol (2022), Founder and Director of the Scripps Research Translational Institute, Leader of The [Topol Review](https://topol.hee.nhs.uk/)


### PR DESCRIPTION
Update fellowship.md
Changed landing page wording to have NHS regions in the 2nd sentence, to be more obvious to readers.