### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/update_stale_repos.yml
+++ b/.github/workflows/update_stale_repos.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v3
     - name: Run stale_repos tool
-      uses: github/stale-repos@v1
+      uses: github-community-projects/stale-repos@v1
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ORGANIZATION: 'GSTT-CSC'


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/stale-repos` | `github-community-projects/stale-repos` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.
